### PR TITLE
Possible HTTP Fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <pluginRepository>
             <id>jcenter-releases</id>
             <name>jcenter</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>
@@ -59,7 +59,7 @@
         <repository>
             <id>jcentral</id>
             <name>bintray</name>
-            <url>http://jcenter.bintray.com</url>
+            <url>https://jcenter.bintray.com</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
JCenter, one of our dependencies, is only using https as of January 2020. Thus the pom needed updating. Travis, I believe, has to download the dependencies every time it tests and thus was unable to reach the dependency URL.