### PR TITLE
fix memberAttributesAdminTest()

### DIFF
--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -278,7 +278,7 @@ public class TestGroupingsRestControllerv2_1 {
         anon = new AnonymousUser();
 
         // Creates not admin or owner user for testing
-        notAdminOwnerUser = new User("notAdminOwner", anonAuthorities);
+        notAdminOwnerUser = new User("notAdminOwner", uhAuthorities);
 
         // add ownership
         memberAttributeService.assignOwnership(GROUPING, ADMIN, usernames[0]);


### PR DESCRIPTION
[GROUPINGS-951](https://www.hawaii.edu/jira/browse/GROUPINGS-951)

- Main problem was the attributes defined in the application.properties file does not match the attributes within the person object that we were returning in getMemberAttributes().
- Another problem was all test users (i.e. iamtst01) was a owner of some group, so it was failing the Current user is not admin or owner test.
- Created isAdminTest() and isOwnerTest() for troubleshooting
- Created [GROUPINGS-961](https://www.hawaii.edu/jira/browse/GROUPINGS-961)

Let me know if theses changes need to be ported to dev-2-2-0