### PR TITLE
Dependabot PR: Bump h2 from 1.4.198 to 2.0.206 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <commons-dbcp-version>2.1.1</commons-dbcp-version>
         <hibernate-jpa.version>1.0.0.Final</hibernate-jpa.version>
         <hibernate.version>5.4.18.Final</hibernate.version>
-        <h2.version>2.0.206</h2.version>
+        <h2.version>1.4.198</h2.version>
         <org.jasig.cas.client-version>3.6.0</org.jasig.cas.client-version>
 
         <swagger2markup.version>1.2.0</swagger2markup.version>


### PR DESCRIPTION
Move back to the previous h2 version, the move up may have been the cause of the stack breakage today.
[GROUPINGS-989](https://www.hawaii.edu/jira/browse/GROUPINGS-989)