### PR TITLE
Fix getMembershipResults()

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupAttributeService.java
@@ -3,10 +3,10 @@ package edu.hawaii.its.api.service;
 import edu.hawaii.its.api.type.Grouping;
 import edu.hawaii.its.api.type.GroupingsServiceResult;
 import edu.hawaii.its.api.type.SyncDestination;
+
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetAttributeAssignmentsResults;
 
 import java.util.List;
-import java.util.Map;
 
 public interface GroupAttributeService {
 

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -57,4 +57,5 @@ public interface GroupingAssignmentService {
     List<String> getOptInGroups(String owner, String optInUid);
 
     List<String> getOptOutGroups(String owner, String optOutUid);
+    List<String> optableGroupings(String optAttr);
 }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentServiceImpl.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentServiceImpl.java
@@ -344,7 +344,6 @@ public class GroupingAssignmentServiceImpl implements GroupingAssignmentService 
         }
     }
 
-
     //returns an adminLists object containing the list of all admins and all groupings
     @Override
     public AdminListsHolder adminLists(String adminUsername) {
@@ -376,7 +375,7 @@ public class GroupingAssignmentServiceImpl implements GroupingAssignmentService 
         List<String> groupingsOpted = new ArrayList<>();
 
         List<String> groupsOpted = groupPaths.stream().filter(group -> group.endsWith(includeOrrExclude)
-                && memberAttributeService.isSelfOpted(group, username)).map(helperService::parentGroupingPath)
+                        && memberAttributeService.isSelfOpted(group, username)).map(helperService::parentGroupingPath)
                 .collect(Collectors.toList());
 
         if (groupsOpted.size() > 0) {
@@ -661,6 +660,26 @@ public class GroupingAssignmentServiceImpl implements GroupingAssignmentService 
         }
         //get rid of duplicates
         return new ArrayList<>(new HashSet<>(opts));
+    }
+
+    /**
+     * List grouping paths than can be opted into or out of.
+     */
+    @Override
+    public List<String> optableGroupings(String optAttr) {
+        if (!optAttr.equals(OPT_IN) && !optAttr.equals(OPT_OUT)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        }
+        WsGetAttributeAssignmentsResults attributeAssignmentsResults =
+                grouperFactoryService.makeWsGetAttributeAssignmentsResultsTrio(ASSIGN_TYPE_GROUP, optAttr);
+        List<WsAttributeAssign> attributeAssigns = Arrays.asList(attributeAssignmentsResults.getWsAttributeAssigns());
+        List<String> optablePaths = new ArrayList<>();
+        attributeAssigns.forEach(attributeAssign -> {
+            if (attributeAssign.getAttributeDefNameName().equals(optAttr)) {
+                optablePaths.add(attributeAssign.getOwnerGroupName());
+            }
+        });
+        return new ArrayList<>(new HashSet<>(optablePaths));
     }
 
     //returns the list of groupings that the user is allowed to opt-in to

--- a/src/main/java/edu/hawaii/its/api/service/MembershipServiceImpl.java
+++ b/src/main/java/edu/hawaii/its/api/service/MembershipServiceImpl.java
@@ -214,7 +214,7 @@ public class MembershipServiceImpl implements MembershipService {
         List<String> optOutList;
         try {
             groupPaths = groupingAssignmentService.getGroupPaths(owner, uid);
-            optOutList = groupingAssignmentService.getOptOutGroups(owner, uid);
+            optOutList = groupingAssignmentService.optableGroupings(OPT_OUT);
         } catch (GcWebServiceError e) {
             return memberships;
         }
@@ -252,13 +252,10 @@ public class MembershipServiceImpl implements MembershipService {
             membership.setPath(groupingPath);
             membership.setOptOutEnabled(optOutList.contains(groupingPath));
             membership.setName(helperService.nameGroupingPath(groupingPath));
-            if (!membership.isInExclude() && !membership.isInBasis()) {
-                memberships.add(membership);
-            }
+            memberships.add(membership);
         }
         return memberships;
     }
-
 
     /**
      * Add all uids/uhUuids contained in list usersToAdd to the group at groupPath. When adding to the include group
@@ -336,8 +333,8 @@ public class MembershipServiceImpl implements MembershipService {
     public List<AddMemberResult> addIncludeMembers(String currentUser, String groupingPath, List<String> usersToAdd) {
         logger.info("addIncludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToAdd: " + usersToAdd + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return addGroupMembers(currentUser, groupingPath + INCLUDE, usersToAdd);
     }
@@ -349,9 +346,9 @@ public class MembershipServiceImpl implements MembershipService {
     public List<AddMemberResult> addExcludeMembers(String currentUser, String groupingPath, List<String> usersToAdd) {
         logger.info("addExcludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToAdd: " + usersToAdd + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
-            }
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        }
         return addGroupMembers(currentUser, groupingPath + EXCLUDE, usersToAdd);
     }
 
@@ -411,8 +408,8 @@ public class MembershipServiceImpl implements MembershipService {
             List<String> usersToRemove) {
         logger.info("removeIncludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToRemove: " + usersToRemove + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return removeGroupMembers(currentUser, groupingPath + INCLUDE, usersToRemove);
     }
@@ -424,8 +421,8 @@ public class MembershipServiceImpl implements MembershipService {
             List<String> usersToRemove) {
         logger.info("removeExcludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToRemove: " + usersToRemove + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return removeGroupMembers(currentUser, groupingPath + EXCLUDE, usersToRemove);
     }

--- a/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
@@ -1,5 +1,6 @@
 package edu.hawaii.its.api.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,5 +33,15 @@ public class JsonUtil {
             // Maybe we should throw something?
         }
         return result;
+    }
+
+    public void printJson(final Object obj) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String json = "{" + objectMapper.writeValueAsString(obj) + "}";
+            System.err.println(json);
+        } catch (JsonProcessingException e) {
+            logger.error("Error: " + e);
+        }
     }
 }

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
@@ -35,7 +35,9 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -112,6 +114,12 @@ public class TestGroupingAssignmentService {
 
     @Value("${groupings.api.insufficient_privileges}")
     private String INSUFFICIENT_PRIVILEGES;
+
+    @Value("${groupings.api.opt_in}")
+    private String OPT_IN;
+
+    @Value("${groupings.api.opt_out}")
+    private String OPT_OUT;
 
     public final Log logger = LogFactory.getLog(GroupingAssignmentServiceImpl.class);
 
@@ -371,6 +379,27 @@ public class TestGroupingAssignmentService {
             assertFalse(path.endsWith(OWNERS));
             // Check for duplicates.
             assertTrue(pathMap.add(path));
+        }
+    }
+
+    @Test
+    public void optableGroupingsTest() {
+        List<String> optInablePaths = groupingAssignmentService.optableGroupings(OPT_IN);
+        List<String> optOutablePaths = groupingAssignmentService.optableGroupings(OPT_OUT);
+        assertNotNull(optInablePaths);
+        assertNotNull(optOutablePaths);
+
+        // Should not have duplicates.
+        Set<String> optInpathMap = new HashSet<>();
+        optInablePaths.forEach(optInablePath -> assertTrue(optInpathMap.add(optInablePath)));
+        Set<String> optOutPathMap = new HashSet<>();
+        optOutablePaths.forEach(optOutablePath -> assertTrue(optOutPathMap.add(optOutablePath)));
+
+        // Should throw an exception if optIn or optOut attribute is not passed.
+        try {
+            groupingAssignmentService.optableGroupings("bad-attribute");
+        } catch (AccessDeniedException e) {
+            assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
         }
     }
 

--- a/src/test/java/edu/hawaii/its/api/service/TestMembershipService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMembershipService.java
@@ -34,10 +34,8 @@ import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Set;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
@@ -103,6 +101,9 @@ public class TestMembershipService {
 
     @Value("${groupings.api.insufficient_privileges}")
     private String INSUFFICIENT_PRIVILEGES;
+
+    @Value("${groupings.api.trio}")
+    private String TRIO;
 
     @Autowired
     GroupAttributeService groupAttributeService;
@@ -182,24 +183,36 @@ public class TestMembershipService {
 
     @Test
     public void getMembershipResultsTest() {
-        List<Membership> memberships = membershipService.getMembershipResults(username[0], username[0]);
-        assertNotNull(memberships);
-        assertTrue(memberships.size() != 0);
-        Set<String> pathMap = new HashSet<>();
-        for (Membership membership : memberships) {
-            assertNotNull(membership.getPath());
-            assertNotNull(membership.getName());
-            // The membership's path should be a parent path.
-            assertFalse(membership.getPath().endsWith(INCLUDE));
-            assertFalse(membership.getPath().endsWith(EXCLUDE));
-            assertFalse(membership.getPath().endsWith(BASIS));
-            assertFalse(membership.getPath().endsWith(OWNERS));
-            // The member should be in at least one of these.
-            assertTrue(membership.isInBasis() || membership.isInExclude() || membership.isInInclude()
-                    || membership.isInOwner());
-            // Check for duplicate paths.
-            assertTrue(pathMap.add(membership.getPath()));
-        }
+        List<String> testUsernames = Arrays.asList(username);
+        List<String> testUsername = new ArrayList<>();
+        testUsername.add(testUsernames.get(0));
+
+        // Should not be a membership if user is not a member.
+        membershipService.removeIncludeMembers(ADMIN, GROUPING, testUsername);
+        membershipService.removeExcludeMembers(ADMIN, GROUPING, testUsername);
+        memberAttributeService.removeOwnership(GROUPING, ADMIN, testUsername.get(0));
+        List<Membership> memberships = membershipService.getMembershipResults(ADMIN, testUsername.get(0));
+        assertTrue(memberships.stream().noneMatch(membership -> membership.getPath().equals(GROUPING)));
+
+        // Should be a membership if user is in exclude.
+        membershipService.addExcludeMembers(ADMIN, GROUPING, testUsername);
+        memberships = membershipService.getMembershipResults(ADMIN, testUsername.get(0));
+        assertTrue(memberships.stream().anyMatch(membership -> membership.getPath().equals(GROUPING)));
+
+        // Should be a membership if user is in include.
+        membershipService.addIncludeMembers(ADMIN, GROUPING, testUsername);
+        memberships = membershipService.getMembershipResults(ADMIN, testUsername.get(0));
+        assertTrue(memberships.stream().anyMatch(membership -> membership.getPath().equals(GROUPING)));
+
+        // Should be a membership if user is in owners and include.
+        memberAttributeService.assignOwnership(GROUPING, ADMIN, testUsername.get(0));
+        memberships = membershipService.getMembershipResults(ADMIN, testUsername.get(0));
+        assertTrue(memberships.stream().anyMatch(membership -> membership.getPath().equals(GROUPING)));
+
+        // Should be a membership if user is only in owners .
+        membershipService.removeExcludeMembers(ADMIN, GROUPING, testUsername);
+        memberships = membershipService.getMembershipResults(ADMIN, testUsername.get(0));
+        assertTrue(memberships.stream().anyMatch(membership -> membership.getPath().equals(GROUPING)));
     }
 
     @Test


### PR DESCRIPTION
---
**Commits (Squashed)**
- Add *printJson()* to ***JsonUtil.java***.
- Remove if statement.
    - The 'if' was filtering out all paths of exclude and in basis, these are still memberships and should be included in *getMembershipResults()* I am assuming this was put here to fix the *getNumberOfMemberships()* functions which I have a feeling should not include exclude and basis memberships and only include and owner to the count.
- Implemtment *optableGroupings()*.
- Cover integrations for *getMembershipResults()*.
- Cover integrations for *optableGroupings()*.
- Check for duplicate paths.
- Fix ***JsonUtil.java***.
---
- [x] Unit Tests
    - [WARNING] Tests run: 357, Failures: 0, Errors: 0, Skipped: 18
- [x] Integrations Tests
    - [WARNING] Tests run: 82, Failures: 0, Errors: 0, Skipped: 8

[GROUPINGS-1040](https://www.hawaii.edu/jira/browse/GROUPINGS-1040)