### PR TITLE
Fix getMembershipResults()

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -236,7 +236,7 @@ public class GroupingsRestControllerv2_1 {
         return ResponseEntity
                 .ok()
                 .body(groupingAssignmentService
-                        .getOptInGroups(currentUser, uid));
+                        .optInGroupingsPaths(currentUser, uid));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/GroupAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupAttributeService.java
@@ -3,10 +3,10 @@ package edu.hawaii.its.api.service;
 import edu.hawaii.its.api.type.Grouping;
 import edu.hawaii.its.api.type.GroupingsServiceResult;
 import edu.hawaii.its.api.type.SyncDestination;
+
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetAttributeAssignmentsResults;
 
 import java.util.List;
-import java.util.Map;
 
 public interface GroupAttributeService {
 

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -54,7 +54,11 @@ public interface GroupingAssignmentService {
 
     List<Grouping> groupingsToOptInto(String optInUsername, List<String> groupPaths);
 
-    List<String> getOptInGroups(String owner, String optInUid);
+    List<String> optInGroupingsPaths(String owner, String optInUid);
 
-    List<String> getOptOutGroups(String owner, String optOutUid);
+    List<String> optOutGroupingsPaths(String owner, String optOutUid);
+
+    List<String> optableGroupings(String optAttr);
+
+    List<String> allGroupingsPaths();
 }

--- a/src/main/java/edu/hawaii/its/api/service/MembershipServiceImpl.java
+++ b/src/main/java/edu/hawaii/its/api/service/MembershipServiceImpl.java
@@ -214,7 +214,7 @@ public class MembershipServiceImpl implements MembershipService {
         List<String> optOutList;
         try {
             groupPaths = groupingAssignmentService.getGroupPaths(owner, uid);
-            optOutList = groupingAssignmentService.getOptOutGroups(owner, uid);
+            optOutList = groupingAssignmentService.optableGroupings(OPT_OUT);
         } catch (GcWebServiceError e) {
             return memberships;
         }
@@ -252,13 +252,10 @@ public class MembershipServiceImpl implements MembershipService {
             membership.setPath(groupingPath);
             membership.setOptOutEnabled(optOutList.contains(groupingPath));
             membership.setName(helperService.nameGroupingPath(groupingPath));
-            if (!membership.isInExclude() && !membership.isInBasis()) {
-                memberships.add(membership);
-            }
+            memberships.add(membership);
         }
         return memberships;
     }
-
 
     /**
      * Add all uids/uhUuids contained in list usersToAdd to the group at groupPath. When adding to the include group
@@ -336,8 +333,8 @@ public class MembershipServiceImpl implements MembershipService {
     public List<AddMemberResult> addIncludeMembers(String currentUser, String groupingPath, List<String> usersToAdd) {
         logger.info("addIncludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToAdd: " + usersToAdd + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return addGroupMembers(currentUser, groupingPath + INCLUDE, usersToAdd);
     }
@@ -349,9 +346,9 @@ public class MembershipServiceImpl implements MembershipService {
     public List<AddMemberResult> addExcludeMembers(String currentUser, String groupingPath, List<String> usersToAdd) {
         logger.info("addExcludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToAdd: " + usersToAdd + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
-            }
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        }
         return addGroupMembers(currentUser, groupingPath + EXCLUDE, usersToAdd);
     }
 
@@ -411,8 +408,8 @@ public class MembershipServiceImpl implements MembershipService {
             List<String> usersToRemove) {
         logger.info("removeIncludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToRemove: " + usersToRemove + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return removeGroupMembers(currentUser, groupingPath + INCLUDE, usersToRemove);
     }
@@ -424,8 +421,8 @@ public class MembershipServiceImpl implements MembershipService {
             List<String> usersToRemove) {
         logger.info("removeExcludeMembers; currentUser: " + currentUser +
                 "; groupingPath: " + groupingPath + "; usersToRemove: " + usersToRemove + ";");
-        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin(currentUser)) {
-                throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
+        if (!memberAttributeService.isOwner(groupingPath, currentUser) && !memberAttributeService.isAdmin( currentUser)) {
+            throw new AccessDeniedException(INSUFFICIENT_PRIVILEGES);
         }
         return removeGroupMembers(currentUser, groupingPath + EXCLUDE, usersToRemove);
     }

--- a/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
@@ -1,5 +1,6 @@
 package edu.hawaii.its.api.util;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -32,5 +33,15 @@ public class JsonUtil {
             // Maybe we should throw something?
         }
         return result;
+    }
+
+    public static void printJson(final Object obj) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            String json = "{" + objectMapper.writeValueAsString(obj) + "}";
+            System.err.println(json);
+        } catch (JsonProcessingException e) {
+            logger.error("Error: " + e);
+        }
     }
 }

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -1,45 +1,9 @@
 package edu.hawaii.its.api.controller;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
-
-import java.util.ArrayList;
-import java.util.List;
-
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithAnonymousUser;
-import org.springframework.test.context.ActiveProfiles;
-import org.springframework.test.context.junit4.SpringRunner;
-import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
-import org.springframework.web.context.WebApplicationContext;
-
 import edu.hawaii.its.api.access.User;
 import edu.hawaii.its.api.access.UserContextService;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
@@ -59,6 +23,41 @@ import edu.hawaii.its.api.type.Membership;
 import edu.hawaii.its.api.type.Person;
 import edu.hawaii.its.api.type.RemoveMemberResult;
 import edu.hawaii.its.api.type.SyncDestination;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithAnonymousUser;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.setup.SecurityMockMvcConfigurers.springSecurity;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
 @RunWith(SpringRunner.class)
 @ActiveProfiles("localTest")
@@ -308,7 +307,6 @@ public class GroupingsRestControllerv2_1Test {
 
     //todo As Nobody
 
-
     //todo This user owns nothing
     //    @Test
     //    @WithMockUhUser(username = "")
@@ -482,14 +480,14 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser
     public void getOptInGroupsTest() throws Exception {
         List<String> optInGroups = new ArrayList<>();
-        given(groupingAssignmentService.getOptInGroups(ADMIN, "iamtst01")).willReturn(optInGroups);
+        given(groupingAssignmentService.optInGroupingsPaths(ADMIN, "iamtst01")).willReturn(optInGroups);
         mockMvc.perform(get(API_BASE + "/groupings/optInGroups/iamtst01")
                         .with(csrf())
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk());
 
         verify(groupingAssignmentService, times(1))
-                .getOptInGroups(ADMIN, "iamtst01");
+                .optInGroupingsPaths(ADMIN, "iamtst01");
     }
 
     @Ignore
@@ -596,8 +594,8 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(jsonPath("$[0].resultCode").value(SUCCESS))
                 .andExpect(jsonPath("$[0].action").value("member is opted-out"));
 
-       verify(groupAttributeService, times(1))
-               .changeOptOutStatus("grouping", USERNAME, true);
+        verify(groupAttributeService, times(1))
+                .changeOptOutStatus("grouping", USERNAME, true);
 
         given(groupAttributeService.changeGroupAttributeStatus("grouping", USERNAME, LISTSERV, true))
                 .willReturn(gsrListserv());
@@ -628,22 +626,26 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithAnonymousUser
     public void anonEnablePreferenceSyncDestTest() throws Exception {
-        MvcResult inResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_IN + "/enable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult inResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_IN + "/enable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(inResult, notNullValue());
 
-        MvcResult outResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_OUT + "/enable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult outResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_OUT + "/enable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(outResult, notNullValue());
 
-        MvcResult listResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + LISTSERV + "/enable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult listResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + LISTSERV + "/enable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(listResult, notNullValue());
 
-        MvcResult groupingResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + RELEASED_GROUPING + "/enable").with(csrf()))
+        MvcResult groupingResult = mockMvc.perform(
+                        put(API_BASE + "/groupings/grouping/syncDests/" + RELEASED_GROUPING + "/enable").with(csrf()))
                 .andExpect(status().is3xxRedirection())
                 .andReturn();
         assertThat(groupingResult, notNullValue());
@@ -705,19 +707,22 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithAnonymousUser
     public void anonDisablePreferenceSyncDestTest() throws Exception {
-        MvcResult inResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_IN + "/disable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult inResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_IN + "/disable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(inResult, notNullValue());
 
-        MvcResult outResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_OUT + "/disable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult outResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_OUT + "/disable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(outResult, notNullValue());
 
-        MvcResult listResult = mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + LISTSERV + "/disable").with(csrf()))
-                .andExpect(status().is3xxRedirection())
-                .andReturn();
+        MvcResult listResult =
+                mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + LISTSERV + "/disable").with(csrf()))
+                        .andExpect(status().is3xxRedirection())
+                        .andReturn();
         assertThat(listResult, notNullValue());
 
         MvcResult groupingResult = mockMvc.perform(
@@ -940,21 +945,21 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser(username = "abc")
     public void lookUpPermissionTestMember() throws Exception {
         MvcResult ownerResult = mockMvc.perform(get(API_BASE + "/owners/" + USERNAME + "/groupings")
-                .header(CURRENT_USER, "0o0-username"))
+                        .header(CURRENT_USER, "0o0-username"))
                 .andDo(print())
                 .andExpect(status().is5xxServerError())
                 .andReturn();
         assertThat(ownerResult, notNullValue());
 
         MvcResult groupingsResult = mockMvc.perform(get(API_BASE + "/members/" + USERNAME + "/groupings")
-                .header(CURRENT_USER, "0o0-username"))
+                        .header(CURRENT_USER, "0o0-username"))
                 .andDo(print())
                 .andExpect(status().is5xxServerError())
                 .andReturn();
         assertThat(groupingsResult, notNullValue());
 
         MvcResult memberAttributeResult = mockMvc.perform(get(API_BASE + "/members/" + USERNAME)
-                .header(CURRENT_USER, "0o0-username"))
+                        .header(CURRENT_USER, "0o0-username"))
                 .andDo(print())
                 .andExpect(status().is5xxServerError())
                 .andReturn();
@@ -1049,20 +1054,22 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser
     public void selfTest() throws Exception {
 
-        MvcResult includeResult = mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/includeMembers/o6-username/self")
-                        .header("current_user", "o6-username")
-                        .header("accept", "application/json"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn();
+        MvcResult includeResult =
+                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/includeMembers/o6-username/self")
+                                .header("current_user", "o6-username")
+                                .header("accept", "application/json"))
+                        .andDo(print())
+                        .andExpect(status().isOk())
+                        .andReturn();
         assertThat(includeResult, notNullValue());
 
-        MvcResult excludeResult = mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/excludeMembers/o6-username/self")
-                        .header("current_user", "o6-username")
-                        .header("accept", "application/json"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andReturn();
+        MvcResult excludeResult =
+                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/excludeMembers/o6-username/self")
+                                .header("current_user", "o6-username")
+                                .header("accept", "application/json"))
+                        .andDo(print())
+                        .andExpect(status().isOk())
+                        .andReturn();
         assertThat(excludeResult, notNullValue());
     }
 

--- a/src/test/java/edu/hawaii/its/api/service/GroupingAssignmentServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/GroupingAssignmentServiceTest.java
@@ -28,7 +28,6 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -243,33 +242,10 @@ public class GroupingAssignmentServiceTest {
     }
 
     @Test
-    public void getOptInGroupsTest() {
-        List<List<String>> optInPathsLists = new ArrayList<List<String>>();
-        for (int i = 0; i < 6; i++) {
-            optInPathsLists.add(new ArrayList<>(
-                    groupingAssignmentService.getOptInGroups(users.get(0).getUsername(), users.get(i).getUsername())));
-        }
-        List<String> assumedPaths = Arrays.asList(GROUPING_0_PATH, GROUPING_1_PATH, GROUPING_3_PATH);
-
-        for (List<String> list : optInPathsLists) {
-            for (String path : list) {
-                assertTrue(assumedPaths.contains(path));
-            }
-        }
-        List<String> optInPaths =
-                groupingAssignmentService.getOptInGroups(users.get(0).getUsername(), users.get(1).getUsername());
-        assertNotNull(optInPaths);
-        Set<String> pathMap = new HashSet<>();
-        for (String path : optInPaths) {
-            // Check for duplicate paths.
-            assertTrue(pathMap.add(path));
-        }
-    }
-
-    @Test
     public void getOptOutGroupsTest() {
         List<String> optOutPaths =
-                groupingAssignmentService.getOptOutGroups(users.get(0).getUsername(), users.get(1).getUsername());
+                groupingAssignmentService.optOutGroupingsPaths(users.get(0).getUsername(),
+                        users.get(1).getUsername());
         assertNotNull(optOutPaths);
         Set<String> pathMap = new HashSet<>();
         for (String path : optOutPaths) {


### PR DESCRIPTION
---
**Commits (Squashed)**
- Add *printJson()* to ***JsonUtil.java***.
- Remove if statement.
    - The 'if' was filtering out all paths of exclude and in basis, these are still memberships and should be included in *getMembershipResults()* I am assuming this was put here to fix the *getNumberOfMemberships()* functions which I have a feeling should not include exclude and basis memberships and only include and owner to the count.
- Implemtment *optableGroupings()*.
- Cover integrations for *getMembershipResults()*.
- Cover integrations for *optableGroupings()*.
- Check for duplicate paths.
- Fix ***JsonUtil.java***.
- Fix indentaion issues.
- Implement *allGroupingsPaths()*.
- Re-implement *getOptOutGroups()*.
- Re-implement *getOptInGroups()*.
- Rename *getOptOutGroups()* to *optOutGroupingsPaths()*.
- Rename *getOptInGroups()* to *optInGroupingsPaths()*.
- Fix Codacy errors.
- Re-implement *optableGroupings()* to only return grouping paths with the optIn or optOut attribute.
---
- [x] Unit Tests
    - [WARNING] Tests run: 357, Failures: 0, Errors: 0, Skipped: 18
- [x] Integrations Tests
    - [WARNING] Tests run: 82, Failures: 0, Errors: 0, Skipped: 8

[GROUPINGS-1040](https://www.hawaii.edu/jira/browse/GROUPINGS-1040)