### PR TITLE
Simplify and shorten test functions in TestMembershipService

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -187,7 +187,7 @@ public class GroupingsRestControllerv2_1 {
         logger.info("Entered REST membershipResults...");
         return ResponseEntity
                 .ok()
-                .body(membershipService.getMembershipResults(currentUser, uid));
+                .body(membershipService.membershipResults(currentUser, uid));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/MembershipService.java
+++ b/src/main/java/edu/hawaii/its/api/service/MembershipService.java
@@ -14,7 +14,7 @@ public interface MembershipService {
 
     List<RemoveMemberResult> removeOwnerships(String groupingPath, String actor, List<String> ownersToRemove);
 
-    List<Membership> getMembershipResults(String owner, String uid);
+    List<Membership> membershipResults(String currentUser, String uid);
 
     List<AddMemberResult> addGroupMembers(String currentUser, String groupPath, List<String> usersToAdd);
 

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -399,7 +399,7 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser
     public void membershipResultsTest() throws Exception {
         List<Membership> memberships = new ArrayList<>();
-        given(membershipService.getMembershipResults(ADMIN, "iamtst01")).willReturn(memberships);
+        given(membershipService.membershipResults(ADMIN, "iamtst01")).willReturn(memberships);
 
         mockMvc.perform(get(API_BASE + "/members/iamtst01/groupings")
                         .with(csrf())
@@ -407,7 +407,7 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))
-                .getMembershipResults(ADMIN, "iamtst01");
+                .membershipResults(ADMIN, "iamtst01");
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/service/TestGrouperApiService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGrouperApiService.java
@@ -9,11 +9,13 @@ import edu.hawaii.its.api.type.Person;
 import edu.hawaii.its.api.util.Dates;
 
 import edu.internet2.middleware.grouperClient.ws.StemScope;
+import edu.internet2.middleware.grouperClient.ws.beans.WsAddMemberResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsAssignAttributesResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsAssignGrouperPrivilegesLiteResult;
 import edu.internet2.middleware.grouperClient.ws.beans.WsAttributeAssign;
 import edu.internet2.middleware.grouperClient.ws.beans.WsAttributeAssignValue;
 import edu.internet2.middleware.grouperClient.ws.beans.WsAttributeDefName;
+import edu.internet2.middleware.grouperClient.ws.beans.WsDeleteMemberResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsFindGroupsResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetGroupsResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetMembersResults;
@@ -21,7 +23,7 @@ import edu.internet2.middleware.grouperClient.ws.beans.WsGetMembershipsResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetSubjectsResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsGroup;
 import edu.internet2.middleware.grouperClient.ws.beans.WsGroupSaveResults;
-import edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResult;
+import edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResults;
 import edu.internet2.middleware.grouperClient.ws.beans.WsSubjectLookup;
 
 import org.springframework.beans.factory.annotation.Autowired;
@@ -163,22 +165,59 @@ public class TestGrouperApiService {
         assertEquals(updatedDescriptionResult, grouperApiService.descriptionOf(GROUPING));
     }
 
-    /* Features coverage of both addMember implementations in GrouperApiService.java. */
     @Test
     public void addMemberTest() {
-        assertNotNull(grouperApiService.addMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0)));
-        assertNotNull(grouperApiService.addMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0)));
+        // With uh usernames.
+        WsAddMemberResults addMemberResults = grouperApiService.addMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        assertNotNull(addMemberResults);
+        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0)));
+
+        addMemberResults = grouperApiService.addMember(GROUPING_INCLUDE, grouperApiService.subjectLookup(ADMIN),
+                TEST_USERNAMES.get(1));
+        assertNotNull(addMemberResults);
+        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_USERNAMES.get(1)));
+        //// Clean up
         grouperApiService.removeMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.removeMember(GROUPING_INCLUDE, TEST_USERNAMES.get(1));
+
+        // With uh numbers.
+        addMemberResults = grouperApiService.addMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0));
+        assertNotNull(addMemberResults);
+        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0)));
+
+        addMemberResults = grouperApiService.addMember(GROUPING_INCLUDE, grouperApiService.subjectLookup(ADMIN),
+                TEST_UH_NUMBERS.get(1));
+        assertNotNull(addMemberResults);
+        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(1)));
+        //// Clean up
         grouperApiService.removeMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0));
+        grouperApiService.removeMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(1));
     }
 
-    /* Features coverage of both removeMember implementations in GrouperApiService.java. */
     @Test
     public void removeMemberTest() {
+        // With uh usernames.
         grouperApiService.addMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.addMember(GROUPING_INCLUDE, TEST_USERNAMES.get(1));
+        WsDeleteMemberResults deleteMemberResults =
+                grouperApiService.removeMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        assertNotNull(deleteMemberResults);
+        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0)));
+        deleteMemberResults = grouperApiService.removeMember(GROUPING_INCLUDE, grouperApiService.subjectLookup(ADMIN),
+                TEST_USERNAMES.get(1));
+        assertNotNull(deleteMemberResults);
+        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_USERNAMES.get(1)));
+
+        // With uh numbers.
         grouperApiService.addMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0));
-        assertNotNull(grouperApiService.removeMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0)));
-        assertNotNull(grouperApiService.removeMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0)));
+        grouperApiService.addMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(1));
+        deleteMemberResults = grouperApiService.removeMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0));
+        assertNotNull(deleteMemberResults);
+        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0)));
+        deleteMemberResults = grouperApiService.removeMember(GROUPING_INCLUDE, grouperApiService.subjectLookup(ADMIN),
+                TEST_UH_NUMBERS.get(1));
+        assertNotNull(deleteMemberResults);
+        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(1)));
     }
 
     @Test
@@ -216,14 +255,24 @@ public class TestGrouperApiService {
 
     @Test
     public void hasMemberResultsTest() {
-        List<WsHasMemberResult> hasMemberResults =
-                Arrays.asList(grouperApiService.hasMemberResults(GROUPING_INCLUDE, TEST_USERNAMES.get(0)).getResults());
+        WsHasMemberResults hasMemberResults =
+                grouperApiService.hasMemberResults(GROUPING_INCLUDE, TEST_UH_NUMBERS.get(0));
         assertNotNull(hasMemberResults);
-        hasMemberResults.forEach(Assertions::assertNotNull);
+        assertNotNull(hasMemberResults);
 
-        hasMemberResults = Arrays.asList(grouperApiService.hasMemberResults(GROUPING_INCLUDE,
-                new Person(TEST_USERNAMES.get(0), TEST_USERNAMES.get(0), TEST_USERNAMES.get(0))).getResults());
-        hasMemberResults.forEach(Assertions::assertNotNull);
+        hasMemberResults =
+                grouperApiService.hasMemberResults(GROUPING_INCLUDE, new Person(null, TEST_USERNAMES.get(0), null));
+        assertNotNull(hasMemberResults);
+
+        hasMemberResults = grouperApiService.hasMemberResults(GROUPING_INCLUDE,
+                new Person(null, TEST_USERNAMES.get(0), TEST_USERNAMES.get(0)));
+        assertNotNull(hasMemberResults);
+
+        try {
+            grouperApiService.hasMemberResults(GROUPING_INCLUDE, new Person(null, null, null)).getResults();
+        } catch (NullPointerException e) {
+            assertEquals("The person is required to have either a username or a uuid", e.getMessage());
+        }
     }
 
     @Test
@@ -277,7 +326,6 @@ public class TestGrouperApiService {
                 true
         );
         assertNotNull(membersResults);
-
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
@@ -104,7 +104,7 @@ public class TestMemberAttributeService {
             assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE,
                     new Person(testUsername, testUsername, testUsername)));
             assertEquals(0,
-                    getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, testUsername)).size());
+                    getMembershipsForCurrentUser(membershipService.membershipResults(ADMIN, testUsername)).size());
         });
 
         // Should be members after add.
@@ -209,7 +209,7 @@ public class TestMemberAttributeService {
     public void getOwnedGroupingsTest() {
         // Groupings owned by current admin should complement the list of memberships that the current admin is in.
         List<GroupingPath> groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, ADMIN);
-        List<Membership> memberships = membershipService.getMembershipResults(ADMIN, ADMIN);
+        List<Membership> memberships = membershipService.membershipResults(ADMIN, ADMIN);
         assertNotNull(groupingsOwned);
         groupingsOwned.forEach(groupingPath -> {
             assertTrue(

--- a/src/test/java/edu/hawaii/its/api/service/TestMembershipService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMembershipService.java
@@ -10,6 +10,7 @@ import edu.hawaii.its.api.type.Membership;
 import edu.hawaii.its.api.type.RemoveMemberResult;
 import edu.hawaii.its.api.type.UpdateTimestampResult;
 import edu.hawaii.its.api.util.Dates;
+import edu.hawaii.its.api.util.JsonUtil;
 
 import edu.internet2.middleware.grouperClient.ws.GcWebServiceError;
 
@@ -24,8 +25,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Iterator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -104,11 +103,12 @@ public class TestMembershipService {
             grouperApiService.removeMember(GROUPING_INCLUDE, testUsername);
             grouperApiService.removeMember(GROUPING_EXCLUDE, testUsername);
             grouperApiService.removeMember(GROUPING_OWNERS, testUsername);
-
-            assertFalse(memberAttributeService.isMember(GROUPING_ADMINS, testUsername));
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, testUsername));
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, testUsername));
-            assertFalse(memberAttributeService.isMember(GROUPING_OWNERS, testUsername));
+        });
+        TEST_UH_NUMBERS.forEach(testNumber -> {
+            grouperApiService.removeMember(GROUPING_ADMINS, testNumber);
+            grouperApiService.removeMember(GROUPING_INCLUDE, testNumber);
+            grouperApiService.removeMember(GROUPING_EXCLUDE, testNumber);
+            grouperApiService.removeMember(GROUPING_OWNERS, testNumber);
         });
     }
 
@@ -180,380 +180,81 @@ public class TestMembershipService {
     }
 
     @Test
-    public void getMembershipResultsTest() {
-        List<String> iamtst01List = new ArrayList<>();
-        String iamtst01 = TEST_USERNAMES.get(0);
-        String iamtst02 = TEST_USERNAMES.get(1);
-        iamtst01List.add(iamtst01);
+    public void membershipResultsTest() {
+        List<Membership> memberships;
 
-        // Should have no memberships.
-        List<Membership> memberships =
-                getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertEquals(0, memberships.size());
+        // Should not be a member.
+        memberships = membershipService.membershipResults(ADMIN, TEST_USERNAMES.get(0));
+        assertTrue(memberships.stream()
+                .noneMatch(membership -> membership.getPath().equals(GROUPING) && !membership.isInBasis()));
 
-        // Should have one membership after being added to include.
-        membershipService.addIncludeMembers(ADMIN, GROUPING, iamtst01List);
-        memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertEquals(1, memberships.size());
-        Membership membership = memberships.get(0);
-        // Should only be in include.
-        assertTrue(membership.isInInclude());
-        assertFalse(membership.isInOwner());
-        assertFalse(membership.isInExclude());
-
-        // Should have one membership after being added to exclude.
-        membershipService.addExcludeMembers(ADMIN, GROUPING, iamtst01List);
-        memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertEquals(1, memberships.size());
-        membership = memberships.get(0);
-        // Should only be in exclude.
-        assertFalse(membership.isInInclude());
-        assertFalse(membership.isInOwner());
+        // Should be a member after added.
+        grouperApiService.addMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+        grouperApiService.addMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.addMember(GROUPING_EXCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.addMember(GROUPING_BASIS, TEST_USERNAMES.get(0));
+        memberships = membershipService.membershipResults(ADMIN, TEST_USERNAMES.get(0));
+        Membership membership = memberships.stream()
+                .filter(m -> m.getPath().equals(GROUPING)).findAny().orElse(null);
+        assertNotNull(membership);
+        assertEquals(GROUPING, membership.getPath());
         assertTrue(membership.isInExclude());
-
-        // Should have one membership after being added to owners.
-        membershipService.addOwnerships(GROUPING, ADMIN, iamtst01List);
-        memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertNotNull(memberships);
-        assertEquals(1, memberships.size());
-        membership = memberships.get(0);
-        // Should be in exclude and in owners.
-        assertFalse(membership.isInInclude());
-        assertTrue(membership.isInOwner());
-        assertTrue(membership.isInExclude());
-
-        // Should have one membership after being added to include.
-        membershipService.addIncludeMembers(ADMIN, GROUPING, iamtst01List);
-        memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertNotNull(memberships);
-        assertEquals(1, memberships.size());
-        membership = memberships.get(0);
-        // Should be in include and in owners.
+        assertTrue(membership.isInBasis());
         assertTrue(membership.isInInclude());
         assertTrue(membership.isInOwner());
-        assertFalse(membership.isInExclude());
+        // Clean up.
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+        grouperApiService.removeMember(GROUPING_INCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.removeMember(GROUPING_EXCLUDE, TEST_USERNAMES.get(0));
+        grouperApiService.removeMember(GROUPING_BASIS, TEST_USERNAMES.get(0));
 
-        // Should have no memberships after being removed from include and owners.
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, iamtst01List);
-        membershipService.removeOwnerships(GROUPING, ADMIN, iamtst01List);
-        memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(ADMIN, iamtst01));
-        assertNotNull(memberships);
-        assertEquals(0, memberships.size());
-
-        // Should throw an exception when a non-admin (username[0]) attempts to fetch the memberships
-        // of another user (username[1]).
+        // Should throw an exception when a non-admin user attempts to fetch memberships of another member.
         try {
-            membershipService.getMembershipResults(iamtst01, iamtst02);
-            fail("Test user \"" + iamtst01 + "\" is an admin.");
+            membershipService.membershipResults(TEST_USERNAMES.get(0), TEST_USERNAMES.get(1));
+            fail("Should throw an exception when a non-admin user attempts to fetch memberships of another member.");
         } catch (AccessDeniedException e) {
             assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
-        }
-
-        // Should successfully fetch another user's (username[1]) memberships if username[0] is an admin.
-        membershipService.addAdmin(ADMIN, iamtst01);
-        try {
-            memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(iamtst01, iamtst02));
-            assertNotNull(memberships);
-            assertTrue(memberships.isEmpty());
-        } catch (AccessDeniedException e) {
-            fail("Test user \"" + iamtst01 + "\" is an admin.");
-        }
-
-        //  Should throw an exception once the user is removed as admin.
-        membershipService.removeAdmin(ADMIN, iamtst01);
-        try {
-            membershipService.getMembershipResults(iamtst01, iamtst02);
-            fail("Test user \"" + iamtst01 + "\" is an admin.");
-        } catch (AccessDeniedException e) {
-            assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
-        }
-
-        // Should not throw an exception if parameters owner and uid match.
-        try {
-            memberships = getMembershipsForCurrentUser(membershipService.getMembershipResults(iamtst01, iamtst01));
-            assertNotNull(memberships);
-            assertTrue(memberships.isEmpty());
-        } catch (AccessDeniedException e) {
-            fail("Should pass if parameters owner and uid match");
         }
 
         // Should throw an exception if bogus-admin is passed as owner.
         try {
-            membershipService.getMembershipResults("bogus-admin", iamtst01);
+            membershipService.membershipResults("bogus-admin", TEST_USERNAMES.get(0));
             fail("Should throw exception if bogus-admin is passed as owner.");
         } catch (AccessDeniedException e) {
             assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
         }
 
+        // Should not throw an exception if current user matches uid and is not an admin.
+        try {
+            membershipService.membershipResults(TEST_USERNAMES.get(0), TEST_USERNAMES.get(0));
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user matches uid and is not an admin.");
+        }
+
+        // Should not throw an exception if current user is an admin and does not match uid.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.membershipResults(TEST_USERNAMES.get(0), "bogus-user");
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and does not match uid.");
+        }
+
+        // Should not throw an exception if current user is an admin and does match uid.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.membershipResults(TEST_USERNAMES.get(0), TEST_USERNAMES.get(0));
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and does match uid.");
+        }
+        grouperApiService.removeMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+
         // Should return and empty list if uid passed is bogus.
-        memberships = membershipService.getMembershipResults(ADMIN, "bogus-user");
+        memberships = membershipService.membershipResults(ADMIN, "bogus-user");
         assertTrue(memberships.isEmpty());
     }
 
     @Test
     public void addGroupMembersTest() {
-        List<String> iamtst01List = new ArrayList<>();
-        String iamtst01 = TEST_USERNAMES.get(0);
-        iamtst01List.add(iamtst01);
-
-        // Add a single user to include group, when user is not a member of include or exclude.
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, iamtst01List.get(0)));
-        List<AddMemberResult> addMemberResults =
-                membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, iamtst01List);
-        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, iamtst01List.get(0)));
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        AddMemberResult addMemberResult = addMemberResults.get(0);
-        assertNotNull(addMemberResult);
-        assertNotNull(addMemberResult.getUid());
-        assertEquals(memberAttributeService.getMemberAttributes(ADMIN, addMemberResult.getUid()).getUsername(),
-                addMemberResult.getUid());
-        assertEquals(SUCCESS, addMemberResult.getResult());
-        assertEquals(GROUPING_INCLUDE, addMemberResult.getPathOfAdd());
-        assertEquals(iamtst01List.get(0), addMemberResult.getUid());
-        assertTrue(addMemberResult.isUserWasAdded());
-        assertFalse(addMemberResult.isUserWasRemoved());
-
-        // Add a single user to include group, when the user is already a member of include.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, iamtst01List);
-        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, iamtst01List.get(0)));
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        addMemberResult = addMemberResults.get(0);
-        assertNotNull(addMemberResult);
-        assertNotNull(addMemberResult.getUid());
-        assertEquals(SUCCESS, addMemberResult.getResult());
-        assertEquals(iamtst01List.get(0), addMemberResult.getUid());
-        assertFalse(addMemberResult.isUserWasAdded());
-        assertFalse(addMemberResult.isUserWasRemoved());
-
-        // Remove user for clean up.
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, iamtst01List);
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, iamtst01List.get(0)));
-
-        assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, iamtst01List.get(0)));
-        // Add a single user to exclude group, when user is not a member of include or exclude.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, iamtst01List);
-        assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iamtst01List.get(0)));
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        addMemberResult = addMemberResults.get(0);
-        assertNotNull(addMemberResult);
-        assertNotNull(addMemberResult.getUid());
-        assertEquals(SUCCESS, addMemberResult.getResult());
-        assertEquals(GROUPING_EXCLUDE, addMemberResult.getPathOfAdd());
-        assertEquals(iamtst01List.get(0), addMemberResult.getUid());
-        assertTrue(addMemberResult.isUserWasAdded());
-        assertFalse(addMemberResult.isUserWasRemoved());
-
-        // Add a single user to exclude group, when the user is already a member of exclude.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, iamtst01List);
-        assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iamtst01List.get(0)));
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        addMemberResult = addMemberResults.get(0);
-        assertNotNull(addMemberResult);
-        assertNotNull(addMemberResult.getUid());
-        assertEquals(SUCCESS, addMemberResult.getResult());
-        assertEquals(iamtst01List.get(0), addMemberResult.getUid());
-        assertFalse(addMemberResult.isUserWasAdded());
-        assertFalse(addMemberResult.isUserWasRemoved());
-
-        // Remove user for clean up.
-        membershipService.removeExcludeMembers(ADMIN, GROUPING, iamtst01List);
-        assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, iamtst01List.get(0)));
-
-        List<String> testUsers01_03 = new ArrayList<>(TEST_USERNAMES.subList(0, 3));
-        List<String> testUsers04_06 = new ArrayList<>(TEST_USERNAMES.subList(3, 6));
-        // Add a list of three users to the include group.
-        for (String user : testUsers01_03) {
-            // Should not be in include.
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-        }
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, testUsers01_03);
-        for (String user : testUsers01_03) {
-            // Should be in include
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers01_03.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_INCLUDE, result.getPathOfAdd());
-            assertTrue(result.isUserWasAdded());
-            assertFalse(result.isUserWasRemoved());
-        }
-        // Add a list of three users who are already in include group.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, testUsers01_03);
-        for (String user : testUsers01_03) {
-            // Should be in include
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers01_03.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_INCLUDE, result.getPathOfAdd());
-            assertFalse(result.isUserWasAdded());
-            assertFalse(result.isUserWasRemoved());
-        }
-        // Add a list of three users to exclude group.
-        for (String user : testUsers04_06) {
-            // Should not be in exclude.
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-        }
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, testUsers04_06);
-        for (String user : testUsers04_06) {
-            // Should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers04_06.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_EXCLUDE, result.getPathOfAdd());
-            assertTrue(result.isUserWasAdded());
-            assertFalse(result.isUserWasRemoved());
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, result.getUid()));
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, result.getUid()));
-        }
-        // Add a list of three users who are already in exclude group.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, testUsers04_06);
-        for (String user : testUsers04_06) {
-            // Should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers04_06.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_EXCLUDE, result.getPathOfAdd());
-            assertFalse(result.isUserWasAdded());
-            assertFalse(result.isUserWasRemoved());
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, result.getUid()));
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, result.getUid()));
-        }
-
-        // Adding the list of test users 1-3 to exclude should remove test users 1-3 from include.
-        Iterator<String> iteratorUsers01_03 = testUsers01_03.iterator();
-        Iterator<String> iteratorUsers04_06 = testUsers04_06.iterator();
-        while (iteratorUsers01_03.hasNext() && iteratorUsers04_06.hasNext()) {
-            // Users 1 - 3 should be in include.
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, iteratorUsers01_03.next()));
-            // Users 4 - 6 should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iteratorUsers04_06.next()));
-        }
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, testUsers01_03);
-        iteratorUsers01_03 = testUsers01_03.iterator();
-        iteratorUsers04_06 = testUsers04_06.iterator();
-        while (iteratorUsers01_03.hasNext() && iteratorUsers04_06.hasNext()) {
-            String user = iteratorUsers01_03.next();
-            // Users 1 - 3 not should be in include.
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-            // Users 1 - 3 should now be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-            // Users 4 - 6 should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iteratorUsers04_06.next()));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers01_03.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_EXCLUDE, result.getPathOfAdd());
-            assertEquals(GROUPING_INCLUDE, result.getPathOfRemoved());
-            assertTrue(result.isUserWasAdded());
-            assertTrue(result.isUserWasRemoved());
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, result.getUid()));
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, result.getUid()));
-        }
-
-        // Adding the list of test users 4 - 6 to include should remove test users 4 - 6 from exclude.
-        iteratorUsers01_03 = testUsers01_03.iterator();
-        iteratorUsers04_06 = testUsers04_06.iterator();
-        while (iteratorUsers01_03.hasNext() && iteratorUsers04_06.hasNext()) {
-            // Users 1 - 3 should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iteratorUsers01_03.next()));
-            // Users 4 - 6 should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iteratorUsers04_06.next()));
-        }
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, testUsers04_06);
-        iteratorUsers01_03 = testUsers01_03.iterator();
-        iteratorUsers04_06 = testUsers04_06.iterator();
-        while (iteratorUsers01_03.hasNext() && iteratorUsers04_06.hasNext()) {
-            String user = iteratorUsers04_06.next();
-            // Users 4 - 6 not should be in exclude.
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-            // Users 4 - 6 should now be in include.
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-            // Users 1 - 3 should be in exclude.
-            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, iteratorUsers01_03.next()));
-        }
-        assertNotNull(addMemberResults);
-        assertEquals(3, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertNotNull(result.getUid());
-            assertEquals(SUCCESS, result.getResult());
-            assertEquals(testUsers04_06.get(addMemberResults.indexOf(result)), result.getUid());
-            assertEquals(GROUPING_INCLUDE, result.getPathOfAdd());
-            assertEquals(GROUPING_EXCLUDE, result.getPathOfRemoved());
-            assertTrue(result.isUserWasAdded());
-            assertTrue(result.isUserWasRemoved());
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, result.getUid()));
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, result.getUid()));
-        }
-
-        // Clean up
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        membershipService.removeExcludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        for (String user : TEST_USERNAMES) {
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, user));
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-        }
-
-        // Add a user using their uh number.
-        // Fetch the admins uh number.
-        List<String> adminsUhNumber = new ArrayList<>();
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, Arrays.asList(ADMIN));
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, ADMIN));
-        adminsUhNumber.add(memberAttributeService.getMemberAttributes(ADMIN, ADMIN).getUhUuid());
-        assertNotNull(adminsUhNumber);
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, adminsUhNumber);
-        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, ADMIN));
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        addMemberResult = addMemberResults.get(0);
-        assertNotNull(addMemberResult);
-        // assertNotNull(addMemberResult.getUid());
-        assertEquals(SUCCESS, addMemberResult.getResult());
-        assertEquals(ADMIN, addMemberResult.getUid());
-        assertTrue(addMemberResult.isUserWasAdded());
-        assertFalse(addMemberResult.isUserWasRemoved());
-
-        // Clean up
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, adminsUhNumber);
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, ADMIN));
-
         // Should throw an exception when a parent group path is passed.
         try {
             membershipService.addGroupMembers(ADMIN, GROUPING, TEST_USERNAMES);
@@ -575,75 +276,67 @@ public class TestMembershipService {
         } catch (GcWebServiceError e) {
             assertEquals("404: Invalid group path.", e.getContainerResponseObject());
         }
-        // Should not throw an exception when a include group path is passed.
-        try {
-            membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
-        } catch (GcWebServiceError e) {
-            fail("Should not throw an exception when an include group path is passed.");
-        }
-        // Should not throw an exception when a exclude group path is passed.
-        try {
-            membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, TEST_USERNAMES);
-        } catch (GcWebServiceError e) {
-            fail("Should not throw an exception when an exclude group path is passed.");
-        }
 
-        // Clean up
-        membershipService.removeExcludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        for (String user : TEST_USERNAMES) {
-            assertFalse(memberAttributeService.isMember(GROUPING_EXCLUDE, user));
-        }
+        // Should add users from a list of uh usernames.
+        List<AddMemberResult> addMemberResults =
+                membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
+        assertEquals(TEST_USERNAMES.size(), addMemberResults.size());
+        assertTrue(addMemberResults.stream().map(AddMemberResult::getUid).collect(Collectors.toList())
+                .containsAll(TEST_USERNAMES));
+        addMemberResults.forEach(addMemberResult -> {
+            assertEquals(SUCCESS, addMemberResult.getResult());
+            assertTrue(addMemberResult.isUserWasAdded());
+            assertFalse(addMemberResult.isUserWasRemoved());
+            assertEquals(GROUPING_INCLUDE, addMemberResult.getPathOfAdd());
+        });
+        TEST_USERNAMES.forEach(testUsername ->
+                assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, testUsername)));
 
-        List<String> bogusTestUsers = new ArrayList<>();
-        bogusTestUsers.add("bogus-1");
-
-        // Should not add a single bogus user to include.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, bogusTestUsers);
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertEquals(FAILURE, result.getResult());
-        }
-
-        // Should not add a single bogus user to exclude.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, bogusTestUsers);
-        assertNotNull(addMemberResults);
-        assertEquals(1, addMemberResults.size());
-        for (AddMemberResult result : addMemberResults) {
-            assertNotNull(result);
-            assertEquals(FAILURE, result.getResult());
-        }
-
-        // Should only add one user, if a list contains one bogus and one legit user.
-        bogusTestUsers.add("iamtst01"); // Add legit user to list.
-        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, bogusTestUsers);
-        assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, bogusTestUsers.get(1)));
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, bogusTestUsers.get(0)));
-        assertNotNull(addMemberResults);
-        assertEquals(2, addMemberResults.size());
-        assertEquals(FAILURE, addMemberResults.get(0).getResult());
-        assertEquals(SUCCESS, addMemberResults.get(1).getResult());
-
-        // Clean up.
-        membershipService.removeIncludeMembers(ADMIN, GROUPING, bogusTestUsers);
-        assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, bogusTestUsers.get(1)));
-
-        // Should add when uh numbers are passed.
+        // Should add users from a list of uh numbers.
         addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_UH_NUMBERS);
-        TEST_UH_NUMBERS.forEach(testUhNumber -> {
-            assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, testUhNumber));
-        });
-        assertNotNull(addMemberResults);
         assertEquals(TEST_UH_NUMBERS.size(), addMemberResults.size());
-        addMemberResults.forEach(res -> {
-            assertEquals(SUCCESS, res.getResult());
-            assertTrue(TEST_UH_NUMBERS.contains(res.getUhUuid()));
+        assertTrue(addMemberResults.stream().map(AddMemberResult::getUhUuid).collect(Collectors.toList())
+                .containsAll(TEST_UH_NUMBERS));
+        addMemberResults.forEach(addMemberResult -> {
+            assertEquals(SUCCESS, addMemberResult.getResult());
+            assertTrue(addMemberResult.isUserWasAdded());
+            assertFalse(addMemberResult.isUserWasRemoved());
+            assertEquals(GROUPING_INCLUDE, addMemberResult.getPathOfAdd());
         });
-        // Clean up
-        TEST_UH_NUMBERS.forEach(testUhNumber -> {
-            grouperApiService.removeMember(GROUPING_INCLUDE, testUhNumber);
+        TEST_UH_NUMBERS.forEach(testNumber ->
+                assertTrue(memberAttributeService.isMember(GROUPING_INCLUDE, testNumber)));
+        // Clean up.
+        TEST_UH_NUMBERS.forEach(testNumber ->
+                grouperApiService.removeMember(GROUPING_INCLUDE, testNumber));
+
+        // Should not add users that are already in the list.
+        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
+        assertEquals(TEST_USERNAMES.size(), addMemberResults.size());
+        addMemberResults.forEach(addMemberResult ->
+                assertFalse(addMemberResult.isUserWasAdded()));
+
+        // Should move users from include to exclude if adding to exclude and user already exists in include.
+        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, TEST_USERNAMES);
+        addMemberResults.forEach(addMemberResult -> {
+            assertEquals(SUCCESS, addMemberResult.getResult());
+            assertTrue(addMemberResult.isUserWasAdded());
+            assertTrue(addMemberResult.isUserWasRemoved());
+            assertEquals(GROUPING_INCLUDE, addMemberResult.getPathOfRemoved());
+            assertEquals(GROUPING_EXCLUDE, addMemberResult.getPathOfAdd());
         });
+        TEST_USERNAMES.forEach(testUsername -> {
+            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, testUsername));
+            assertTrue(memberAttributeService.isMember(GROUPING_EXCLUDE, testUsername));
+        });
+        // Clean up.
+        TEST_USERNAMES.forEach(testUsername -> grouperApiService.removeMember(GROUPING_EXCLUDE, testUsername));
+
+        // Should return a failed AddMemberResult if user to add is invalid.
+        List<String> bogusUserToAdd = new ArrayList<>();
+        bogusUserToAdd.add("bogus-user");
+        addMemberResults = membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, bogusUserToAdd);
+        assertTrue(addMemberResults.stream().allMatch(addMemberResult -> addMemberResult.getResult().equals(FAILURE)));
+        JsonUtil.printJson(addMemberResults);
 
     }
 
@@ -666,18 +359,30 @@ public class TestMembershipService {
             fail("Should not throw an exception if current user is an admin.");
         }
 
-        // Should not throw an exception if current user is an owner and an admin.
-        List<String> adminList = new ArrayList<>();
-        adminList.add(TEST_USERNAMES.get(0));
-        membershipService.addOwnerships(GROUPING, ADMIN, adminList);
-        assertTrue(memberAttributeService.isMember(GROUPING_OWNERS, TEST_USERNAMES.get(0)));
+        // Should not throw an exception if current user is an owner but not an admin.
+        grouperApiService.addMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
         try {
             membershipService.addIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
         } catch (AccessDeniedException e) {
-            fail("Should not throw an exception if current user is an owner and an admin.");
+            fail("Should not throw an exception if current user is an owner but not an admin.");
         }
-        membershipService.removeOwnerships(GROUPING, ADMIN, adminList);
-        assertFalse(memberAttributeService.isMember(GROUPING_OWNERS, TEST_USERNAMES.get(0)));
+
+        // Should not throw an exception if current user is an admin and an owner.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.addIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+
+        // Should not throw an exception if current user is admin but not an owner.
+        try {
+            membershipService.addIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is admin but not an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
 
         // Should throw an exception if currentUser is not an admin or owner.
         String iamtst01 = TEST_USERNAMES.get(0);
@@ -739,18 +444,30 @@ public class TestMembershipService {
             fail("Should not throw an exception if current user is an admin.");
         }
 
-        // Should not throw an exception if current user is an owner and an admin.
-        List<String> adminList = new ArrayList<>();
-        adminList.add(TEST_USERNAMES.get(0));
-        membershipService.addOwnerships(GROUPING, ADMIN, adminList);
-        assertTrue(memberAttributeService.isMember(GROUPING_OWNERS, TEST_USERNAMES.get(0)));
+        // Should not throw an exception if current user is an owner but not an admin.
+        grouperApiService.addMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
         try {
             membershipService.addExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
         } catch (AccessDeniedException e) {
-            fail("Should not throw an exception if current user is an owner and an admin.");
+            fail("Should not throw an exception if current user is an owner but not an admin.");
         }
-        membershipService.removeOwnerships(GROUPING, ADMIN, adminList);
-        assertFalse(memberAttributeService.isMember(GROUPING_OWNERS, TEST_USERNAMES.get(0)));
+
+        // Should not throw an exception if current user is an admin and an owner.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.addExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+
+        // Should not throw an exception if current user is admin but not an owner.
+        try {
+            membershipService.addExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToAdd);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is admin but not an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
 
         // Should throw an exception if currentUser is not an admin or owner.
         String iamtst01 = TEST_USERNAMES.get(0);
@@ -797,13 +514,10 @@ public class TestMembershipService {
     public void removeGroupMembersTest() {
         List<RemoveMemberResult> removeMemberResults;
         // Should remove users by passing uh usernames.
-        TEST_USERNAMES.forEach(testUsername -> {
-            grouperApiService.addMember(GROUPING_INCLUDE, testUsername);
-        });
+        TEST_USERNAMES.forEach(testUsername -> grouperApiService.addMember(GROUPING_INCLUDE, testUsername));
         removeMemberResults = membershipService.removeGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
-        TEST_USERNAMES.forEach(testUserName -> {
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, testUserName));
-        });
+        TEST_USERNAMES.forEach(
+                testUserName -> assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, testUserName)));
         assertNotNull(removeMemberResults);
         assertEquals(TEST_USERNAMES.size(), removeMemberResults.size());
         removeMemberResults.forEach(removeMemberResult -> {
@@ -814,13 +528,9 @@ public class TestMembershipService {
         });
 
         // Should remove users by passing uh numbers.
-        TEST_UH_NUMBERS.forEach(uhNumber -> {
-            grouperApiService.addMember(GROUPING_INCLUDE, uhNumber);
-        });
+        TEST_UH_NUMBERS.forEach(uhNumber -> grouperApiService.addMember(GROUPING_INCLUDE, uhNumber));
         removeMemberResults = membershipService.removeGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_UH_NUMBERS);
-        TEST_UH_NUMBERS.forEach(uhNumber -> {
-            assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, uhNumber));
-        });
+        TEST_UH_NUMBERS.forEach(uhNumber -> assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, uhNumber)));
         assertNotNull(removeMemberResults);
         assertEquals(TEST_UH_NUMBERS.size(), removeMemberResults.size());
         removeMemberResults.forEach(removeMemberResult -> {
@@ -829,6 +539,13 @@ public class TestMembershipService {
             assertEquals(GROUPING_INCLUDE, removeMemberResult.getPathOfRemoved());
             assertTrue(TEST_UH_NUMBERS.contains(removeMemberResult.getUhUuid()));
         });
+
+        // Should return a failed RemoveMemberResult if user to remove is invalid.
+        List<String> bogusUserToRemove = new ArrayList<>();
+        bogusUserToRemove.add("bogus-user");
+        removeMemberResults = membershipService.removeGroupMembers(ADMIN, GROUPING_INCLUDE, bogusUserToRemove);
+        assertTrue(removeMemberResults.stream()
+                .allMatch(removeMemberResult -> removeMemberResult.getResult().equals(FAILURE)));
 
         // Should throw an exception when a parent group path is passed.
         try {
@@ -851,15 +568,15 @@ public class TestMembershipService {
         } catch (GcWebServiceError e) {
             assertEquals("404: Invalid group path.", e.getContainerResponseObject());
         }
-        // Should not throw an exception when a include group path is passed.
-        membershipService.addGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
+        // Should not throw an exception when an include group path is passed.
+        TEST_USERNAMES.forEach(testUsername -> grouperApiService.addMember(GROUPING_INCLUDE, testUsername));
         try {
             membershipService.removeGroupMembers(ADMIN, GROUPING_INCLUDE, TEST_USERNAMES);
         } catch (GcWebServiceError e) {
             fail("Should not throw an exception when an include group path is passed.");
         }
-        // Should not throw an exception when a exclude group path is passed.
-        membershipService.addGroupMembers(ADMIN, GROUPING_EXCLUDE, TEST_USERNAMES);
+        // Should not throw an exception when an exclude group path is passed.
+        TEST_USERNAMES.forEach(testUsername -> grouperApiService.addMember(GROUPING_EXCLUDE, testUsername));
         try {
             membershipService.removeGroupMembers(ADMIN, GROUPING_EXCLUDE, TEST_USERNAMES);
         } catch (GcWebServiceError e) {
@@ -888,24 +605,39 @@ public class TestMembershipService {
             fail("Should not throw an exception if current user is an admin.");
         }
 
-        // Should not throw an exception if current user is an owner and an admin.
-        List<String> adminList = new ArrayList<>();
-        adminList.add(iamtst01);
-        membershipService.addOwnerships(GROUPING, ADMIN, adminList);
+        // Should not throw an exception if current user is an owner but not an admin.
+        grouperApiService.addMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
         try {
-            membershipService.removeIncludeMembers(iamtst01, GROUPING, bogusUsersToRemove);
+            membershipService.removeIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
         } catch (AccessDeniedException e) {
-            fail("Should not throw an exception if current user is an owner and an admin.");
+            fail("Should not throw an exception if current user is an owner but not an admin.");
         }
-        membershipService.removeOwnerships(GROUPING, ADMIN, adminList);
+
+        // Should not throw an exception if current user is an admin and an owner.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.removeIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+
+        // Should not throw an exception if current user is admin but not an owner.
+        try {
+            membershipService.removeIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is admin but not an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
 
         // Should throw an exception if currentUser is not an admin or owner.
         try {
-            membershipService.removeIncludeMembers(iamtst01, GROUPING, null);
+            membershipService.removeIncludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
             fail("Should throw an exception if currentUser is not an admin or owner.");
         } catch (AccessDeniedException e) {
             assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
         }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
 
         // Should throw an exception if a group path is passed.
         try {
@@ -951,16 +683,39 @@ public class TestMembershipService {
             fail("Should not throw an exception if current user is an admin.");
         }
 
-        // Should not throw an exception if current user is an owner and an admin.
-        List<String> adminList = new ArrayList<>();
-        adminList.add(iamtst01);
-        membershipService.addOwnerships(GROUPING, ADMIN, adminList);
+        // Should not throw an exception if current user is an owner but not an admin.
+        grouperApiService.addMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
         try {
-            membershipService.removeExcludeMembers(iamtst01, GROUPING, bogusUsersToRemove);
+            membershipService.removeExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
         } catch (AccessDeniedException e) {
-            fail("Should not throw an exception if current user is an owner and an admin.");
+            fail("Should not throw an exception if current user is an owner but not an admin.");
         }
-        membershipService.removeOwnerships(GROUPING, ADMIN, adminList);
+
+        // Should not throw an exception if current user is an admin and an owner.
+        grouperApiService.addMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+        try {
+            membershipService.removeExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is an admin and an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
+
+        // Should not throw an exception if current user is admin but not an owner.
+        try {
+            membershipService.removeExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if current user is admin but not an owner.");
+        }
+        grouperApiService.removeMember(GROUPING_ADMINS, TEST_USERNAMES.get(0));
+
+        // Should throw an exception if currentUser is not an admin or owner.
+        try {
+            membershipService.removeExcludeMembers(TEST_USERNAMES.get(0), GROUPING, bogusUsersToRemove);
+            fail("Should throw an exception if currentUser is not an admin or owner.");
+        } catch (AccessDeniedException e) {
+            assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
+        }
+        grouperApiService.removeMember(GROUPING_OWNERS, TEST_USERNAMES.get(0));
 
         // Should throw an exception if currentUser is not an admin or owner.
         try {
@@ -1104,7 +859,7 @@ public class TestMembershipService {
         assertFalse(memberAttributeService.isOwner(GROUPING, iamtst01List.get(0)));
         assertFalse(memberAttributeService.isAdmin(iamtst01List.get(0)));
         try {
-            membershipService.addOwnerships(GROUPING, iamtst01List.get(0), iamtst01List);
+            membershipService.addOwnerships(GROUPING, iamtst01List.get(0), null);
             fail("Should throw an exception if current user is not an admin or owner.");
         } catch (AccessDeniedException e) {
             assertEquals(INSUFFICIENT_PRIVILEGES, e.getMessage());
@@ -1119,8 +874,25 @@ public class TestMembershipService {
         } catch (AccessDeniedException e) {
             fail(" Should not throw an exception if the current user is not an admin but is an owner.");
         }
+
+        // Should not throw an exception if the current user is an admin an and an owner.
+        grouperApiService.addMember(GROUPING_ADMINS, iamtst01List.get(0));
+        try {
+            membershipService.addOwnerships(GROUPING, iamtst01List.get(0), iamtst01List);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if the current user is an admin an and an owner.");
+        }
+
+        // Should not throw an exception if the current user is an admin an and not an owner.
+        grouperApiService.removeMember(GROUPING_OWNERS, iamtst01List.get(0));
+        try {
+            membershipService.addOwnerships(GROUPING, iamtst01List.get(0), iamtst01List);
+        } catch (AccessDeniedException e) {
+            fail("Should not throw an exception if the current user is an admin an and not an owner.");
+        }
         // Clean up.
-        membershipService.removeOwnerships(GROUPING, ADMIN, iamtst01List);
+        grouperApiService.removeMember(GROUPING_ADMINS, iamtst01List.get(0));
+        grouperApiService.removeMember(GROUPING_OWNERS, iamtst01List.get(0));
     }
 
     @Test
@@ -1224,6 +996,17 @@ public class TestMembershipService {
 
     @Test
     public void removeFromGroupsTest() {
+        // Should throw an exception if groupPaths contains paths that are not include, exclude, or owners.
+        List<String> badPaths = new ArrayList<>();
+        badPaths.add(GROUPING_BASIS);
+        badPaths.add(GROUPING);
+        try {
+            membershipService.removeFromGroups(ADMIN, TEST_USERNAMES.get(0), badPaths);
+            fail("Should throw an exception if groupPaths contains paths that are not include, exclude, or owners.");
+        } catch (GcWebServiceError e) {
+            assertEquals("404: Invalid group path.", e.getContainerResponseObject());
+        }
+
         // Should throw an exception if current user is not an admin.
         try {
             membershipService.removeFromGroups(TEST_USERNAMES.get(0), null, null);
@@ -1392,7 +1175,7 @@ public class TestMembershipService {
      */
     private List<Membership> getMembershipsForCurrentUser(List<Membership> memberships) {
         return memberships
-                .stream().filter(membership -> membership.getPath().contains(GROUPING))
+                .stream().filter(membership -> membership.getPath().equals(GROUPING))
                 .collect(Collectors.toList())
                 .stream().filter(membership -> !membership.isInBasis()).collect(Collectors.toList());
     }


### PR DESCRIPTION
*Commits* (squashed)
- Re-cover ***addGroupMembers()***.
- Remove brackets.
- Remove try/catch from ***removeGroupMembers()***, grouper does not throw exception when an invalid subject is passed.
- Shorten ***getMembershipResultsTest()***.
- Simplify ***init()*** method.
- Cover ***getMembershipResults()***.
    - Refactor ***getMembershipResults()*** to ***membershipResults()***.
- Cover ***GrouperApiService***.*addMember()*.
- Cover ***GrouperApiService***.*removeMembers()*.
- Cover ***GrouperApiService***.*hasMemberResults()*.
- Cover ***MembershipService.java***..
- Remove lambda style loop.
---
- [x] Unit Tests
    - [INFO] Tests run: 202, Failures: 0, Errors: 0, Skipped: 1
- [x] Integrations Tests
    - [INFO] Tests run: 95, Failures: 0, Errors: 0, Skipped: 0
---
[GROUPINGS-1050](https://www.hawaii.edu/jira/browse/GROUPINGS-1050)