### PR TITLE
Adjust endpoints to match new API bible documentation.

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -76,7 +76,8 @@ public class GroupingsRestControllerv2_1 {
      * Get a hello string, this is a test endpoint.
      */
     @GetMapping(value = "/")
-    @ResponseBody public ResponseEntity<String> hello() {
+    @ResponseBody
+    public ResponseEntity<String> hello() {
         return ResponseEntity
                 .ok()
                 .body("University of Hawaii Groupings");
@@ -85,7 +86,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get a list of all admins and a list of all groupings.
      */
-    @GetMapping(value = "/adminsGroupings")
+    @GetMapping(value = "/admins-and-groupings")
     @ResponseBody
     public ResponseEntity<AdminListsHolder> adminsGroupings(@RequestHeader(CURRENT_USER) String currentUser) {
         logger.info("Entered REST adminsGroupings...");
@@ -135,7 +136,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Remove all members from basis, include, exclude.
      */
-    @DeleteMapping(value = "/groupings/{path}/{include}/{exclude}/resetGroup")
+    @DeleteMapping(value = "/groupings/{path}/{include}/{exclude}/reset-group")
     public ResponseEntity<List<RemoveMemberResult>> resetGroup(@RequestHeader(CURRENT_USER) String owner,
             @PathVariable String path,
             @PathVariable List<String> include, @PathVariable List<String> exclude) {
@@ -193,7 +194,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get a list of all the paths associated with the groupings which uid as the ability top opt into.
      */
-    @GetMapping(value = "/groupings/optInGroups/{uid}")
+    @GetMapping(value = "/groupings/members/{uid}/opt-in-groups")
     @ResponseBody
     public ResponseEntity<List<String>> getOptInGroups(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String uid) {
@@ -207,7 +208,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Make a user of uid a member of the include group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/includeMembers/{uid:[\\w-:.]+}/self")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uid:[\\w-:.]+}/self")
     public ResponseEntity<List<AddMemberResult>> optIn(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path, @PathVariable String uid) {
         logger.info("Entered REST optIn...");
@@ -219,7 +220,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Make a user of uid a member of the exclude group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/excludeMembers/{uid:[\\w-:.]+}/self")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uid:[\\w-:.]+}/self")
     public ResponseEntity<List<AddMemberResult>> optOut(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path, @PathVariable String uid) {
         logger.info("Entered REST optOut...");
@@ -231,51 +232,51 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Add a list of users to the include group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/includeMembers/{usersToAdd}")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uids}")
     public ResponseEntity<List<AddMemberResult>> addIncludeMembers(@RequestHeader(CURRENT_USER) String currentUser,
-            @PathVariable String path, @PathVariable List<String> usersToAdd) {
+            @PathVariable String path, @PathVariable List<String> uids) {
         logger.info("Entered REST addIncludeMembers...");
         return ResponseEntity
                 .ok()
-                .body(membershipService.addIncludeMembers(currentUser, path, usersToAdd));
+                .body(membershipService.addIncludeMembers(currentUser, path, uids));
     }
 
     /**
      * Add a list of users to the exclude group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/excludeMembers/{usersToAdd}")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uids}")
     public ResponseEntity<List<AddMemberResult>> addExcludeMembers(@RequestHeader(CURRENT_USER) String currentUser,
-            @PathVariable String path, @PathVariable List<String> usersToAdd) {
+            @PathVariable String path, @PathVariable List<String> uids) {
         logger.info("Entered REST addExcludeMembers...");
         return ResponseEntity
                 .ok()
-                .body(membershipService.addExcludeMembers(currentUser, path, usersToAdd));
+                .body(membershipService.addExcludeMembers(currentUser, path, uids));
     }
 
     /**
      * Remove a list of users from the include group of grouping at path.
      */
-    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/includeMembers/{usersToRemove}")
+    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uids}")
     public ResponseEntity<List<RemoveMemberResult>> removeIncludeMembers(
             @RequestHeader(CURRENT_USER) String currentUser, @PathVariable String path,
-            @PathVariable List<String> usersToRemove) {
+            @PathVariable List<String> uids) {
         logger.info("Entered REST removeIncludeMembers...");
         return ResponseEntity
                 .ok()
-                .body(membershipService.removeIncludeMembers(currentUser, path, usersToRemove));
+                .body(membershipService.removeIncludeMembers(currentUser, path, uids));
     }
 
     /**
      * Remove a list of users from the exclude include group of grouping at path.
      */
-    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/excludeMembers/{usersToRemove}")
+    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uids}")
     public ResponseEntity<List<RemoveMemberResult>> removeExcludeMembers(
             @RequestHeader(CURRENT_USER) String currentUser, @PathVariable String path,
-            @PathVariable List<String> usersToRemove) {
+            @PathVariable List<String> uids) {
         logger.info("Entered REST removeExcludeMembers...");
         return ResponseEntity
                 .ok()
-                .body(membershipService.removeExcludeMembers(currentUser, path, usersToRemove));
+                .body(membershipService.removeExcludeMembers(currentUser, path, uids));
     }
 
     /**
@@ -333,43 +334,43 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Update grouping to enable given preference.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/syncDests/{syncDestName:[\\w-:.]+}/enable")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/sync-destination/{id:[\\w-:.]+}/enable")
     public ResponseEntity<GroupingsServiceResult> enableSyncDest(
             @RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path,
-            @PathVariable String syncDestName) {
+            @PathVariable String id) {
         return ResponseEntity
                 .ok()
-                .body(groupAttributeService.changeGroupAttributeStatus(path, currentUser, syncDestName, true));
+                .body(groupAttributeService.changeGroupAttributeStatus(path, currentUser, id, true));
     }
 
     /**
      * Update grouping to disable given preference.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/syncDests/{syncDestName:[\\w-:.]+}/disable")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/sync-destination/{id:[\\w-:.]+}/disable")
     public ResponseEntity<GroupingsServiceResult> disableSyncDest(
             @RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path,
-            @PathVariable String syncDestName) {
+            @PathVariable String id) {
         return ResponseEntity
                 .ok()
-                .body(groupAttributeService.changeGroupAttributeStatus(path, currentUser, syncDestName, false));
+                .body(groupAttributeService.changeGroupAttributeStatus(path, currentUser, id, false));
     }
 
     /**
      * Update grouping to enable given preference.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/preferences/{preferenceId:[\\w-:.]+}/enable")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/preference/{id:[\\w-:.]+}/enable")
     public ResponseEntity<List<GroupingsServiceResult>> enablePreference(
             @RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path,
-            @PathVariable String preferenceId) {
+            @PathVariable String id) {
         logger.info("Entered REST enablePreference");
         List<GroupingsServiceResult> results;
 
-        if (OPT_IN.equals(preferenceId)) {
+        if (OPT_IN.equals(id)) {
             results = groupAttributeService.changeOptInStatus(path, currentUser, true);
-        } else if (OPT_OUT.equals(preferenceId)) {
+        } else if (OPT_OUT.equals(id)) {
             results = groupAttributeService.changeOptOutStatus(path, currentUser, true);
         } else {
             throw new UnsupportedOperationException();
@@ -383,19 +384,19 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Update grouping to disable given preference.
      */
-    @RequestMapping(value = "/groupings/{path:[\\w-:.]+}/preferences/{preferenceId:[\\w-:.]+}/disable",
+    @RequestMapping(value = "/groupings/{path:[\\w-:.]+}/preference/{id:[\\w-:.]+}/disable",
             method = RequestMethod.PUT,
             produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<List<GroupingsServiceResult>> disablePreference(
             @RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path,
-            @PathVariable String preferenceId) {
+            @PathVariable String id) {
         logger.info("Entered REST disablePreference");
         List<GroupingsServiceResult> results;
 
-        if (OPT_IN.equals(preferenceId)) {
+        if (OPT_IN.equals(id)) {
             results = groupAttributeService.changeOptInStatus(path, currentUser, false);
-        } else if (OPT_OUT.equals(preferenceId)) {
+        } else if (OPT_OUT.equals(id)) {
             results = groupAttributeService.changeOptOutStatus(path, currentUser, false);
         } else {
             throw new UnsupportedOperationException();
@@ -408,7 +409,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get the list of sync destinations.
      */
-    @RequestMapping(value = "/groupings/{path:[\\w-:.]+}/syncDestinations",
+    @RequestMapping(value = "/groupings/{path:[\\w-:.]+}/sync-destinations",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
@@ -461,7 +462,7 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get the number of memberships the current user has
      */
-    @GetMapping(value = "/groupings/{uid:[\\w-:.<>]+}/memberships")
+    @GetMapping(value = "/groupings/members/{uid:[\\w-:.<>]+}/memberships")
     @ResponseBody
     public ResponseEntity<Integer> getNumberOfMemberships(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String uid) {
@@ -474,13 +475,13 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Check if the user is a sole owner of a grouping
      */
-    @GetMapping(value = "/{path:[\\w-:.]+}/owners/{uidToCheck}")
+    @GetMapping(value = "/groupings/{path:[\\w-:.]+}/owners/{uid}")
     @ResponseBody
     public ResponseEntity<Boolean> isSoleOwner(@RequestHeader(CURRENT_USER) String currentUser,
-            @PathVariable String path, @PathVariable String uidToCheck) {
+            @PathVariable String path, @PathVariable String uid) {
         logger.info("Entered REST getGroupingOwners...");
         return ResponseEntity
                 .ok()
-                .body(groupingAssignmentService.isSoleOwner(currentUser, path, uidToCheck));
+                .body(groupingAssignmentService.isSoleOwner(currentUser, path, uid));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -239,7 +239,7 @@ public class GroupingsRestControllerv2_1Test {
         AdminListsHolder adminListsHolder = new AdminListsHolder(groupingPaths, adminGroup);
 
         given(groupingAssignmentService.adminLists("bobo")).willReturn(adminListsHolder);
-        mockMvc.perform(get(API_BASE + "/adminsGroupings")
+        mockMvc.perform(get(API_BASE + "/admins-and-groupings")
                         .header(CURRENT_USER, "bobo"))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("allGroupingPaths[0].name").value("grouping0"))
@@ -323,7 +323,7 @@ public class GroupingsRestControllerv2_1Test {
         MvcResult result =
                 mockMvc.perform(
                                 delete(API_BASE + "/groupings/grouping/" + includePathsStr + "/" + excludePathsStr
-                                        + "/resetGroup")
+                                        + "/reset-group")
                                         .with(csrf())
                                         .header(CURRENT_USER, ADMIN))
                         .andExpect(status().isOk())
@@ -410,7 +410,7 @@ public class GroupingsRestControllerv2_1Test {
     public void getOptInGroupsTest() throws Exception {
         List<String> optInGroups = new ArrayList<>();
         given(groupingAssignmentService.optInGroupingsPaths(ADMIN, "iamtst01")).willReturn(optInGroups);
-        mockMvc.perform(get(API_BASE + "/groupings/optInGroups/iamtst01")
+        mockMvc.perform(get(API_BASE + "/groupings/members/iamtst01/opt-in-groups")
                         .with(csrf())
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk());
@@ -423,7 +423,7 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser
     public void optInTest() throws Exception {
         MvcResult includeResult =
-                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/includeMembers/o6-username/self")
+                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/include-members/o6-username/self")
                                 .header("current_user", "o6-username")
                                 .header("accept", "application/json"))
                         .andDo(print())
@@ -436,7 +436,7 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhUser
     public void optOutTest() throws Exception {
         MvcResult excludeResult =
-                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/excludeMembers/o6-username/self")
+                mockMvc.perform(put(API_BASE + "/groupings/test:ing:me:kim/exclude-members/o6-username/self")
                                 .header("current_user", "o6-username")
                                 .header("accept", "application/json"))
                         .andDo(print())
@@ -455,7 +455,7 @@ public class GroupingsRestControllerv2_1Test {
         usersToAdd.add("tst06name");
         given(membershipService.addIncludeMembers(USERNAME, "grouping", usersToAdd))
                 .willReturn(addMemberResults);
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/includeMembers/" + String.join(",", usersToAdd))
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/include-members/" + String.join(",", usersToAdd))
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk());
@@ -475,7 +475,7 @@ public class GroupingsRestControllerv2_1Test {
         given(membershipService.addExcludeMembers(USERNAME, "grouping", usersToAdd))
                 .willReturn(addMemberResults);
 
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/excludeMembers/" + String.join(",", usersToAdd))
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/exclude-members/" + String.join(",", usersToAdd))
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk());
@@ -494,7 +494,7 @@ public class GroupingsRestControllerv2_1Test {
         usersToRemove.add("tst06name");
         given(membershipService.removeIncludeMembers(USERNAME, "grouping", usersToRemove))
                 .willReturn(removeMemberResults);
-        mockMvc.perform(delete(API_BASE + "/groupings/grouping/includeMembers/" + String.join(",", usersToRemove))
+        mockMvc.perform(delete(API_BASE + "/groupings/grouping/include-members/" + String.join(",", usersToRemove))
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk());
@@ -513,7 +513,7 @@ public class GroupingsRestControllerv2_1Test {
         usersToRemove.add("tst06name");
         given(membershipService.removeExcludeMembers(USERNAME, "grouping", usersToRemove))
                 .willReturn(removeMemberResults);
-        mockMvc.perform(delete(API_BASE + "/groupings/grouping/excludeMembers/" + String.join(",", usersToRemove))
+        mockMvc.perform(delete(API_BASE + "/groupings/grouping/exclude-members/" + String.join(",", usersToRemove))
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk());
@@ -615,7 +615,7 @@ public class GroupingsRestControllerv2_1Test {
     public void enablePreferenceSyncDestTest() throws Exception {
         given(groupAttributeService.changeOptInStatus("grouping", USERNAME, true))
                 .willReturn(gsrListIn());
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_IN + "/enable")
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/preference/" + OPT_IN + "/enable")
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk())
@@ -627,7 +627,7 @@ public class GroupingsRestControllerv2_1Test {
 
         given(groupAttributeService.changeOptOutStatus("grouping", USERNAME, true))
                 .willReturn(gsrListOut());
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/preferences/" + OPT_OUT + "/enable")
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/preference/" + OPT_OUT + "/enable")
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk())
@@ -639,7 +639,7 @@ public class GroupingsRestControllerv2_1Test {
 
         given(groupAttributeService.changeGroupAttributeStatus("grouping", USERNAME, LISTSERV, true))
                 .willReturn(gsrListserv());
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + LISTSERV + "/enable")
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/sync-destination/" + LISTSERV + "/enable")
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk())
@@ -651,7 +651,7 @@ public class GroupingsRestControllerv2_1Test {
 
         given(groupAttributeService.changeGroupAttributeStatus("grouping", USERNAME, RELEASED_GROUPING, true))
                 .willReturn(gsrReleasedGrouping());
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/syncDests/" + RELEASED_GROUPING + "/enable")
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/sync-destination/" + RELEASED_GROUPING + "/enable")
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk())
@@ -668,7 +668,7 @@ public class GroupingsRestControllerv2_1Test {
         given(groupAttributeService.getAllSyncDestinations(USERNAME, "grouping"))
                 .willReturn(sdList());
 
-        mockMvc.perform(get(API_BASE + "/groupings/grouping/syncDestinations")
+        mockMvc.perform(get(API_BASE + "/groupings/grouping/sync-destinations")
                         .with(csrf())
                         .header(CURRENT_USER, USERNAME))
                 .andExpect(status().isOk());
@@ -756,7 +756,7 @@ public class GroupingsRestControllerv2_1Test {
         Grouping group = groupingTwo();
         System.out.println(group.getOwners());
 
-        MvcResult result = mockMvc.perform(get(API_BASE + "/groupings/syncDestinations")
+        MvcResult result = mockMvc.perform(get(API_BASE + "/groupings/sync-destinations")
                         .header("current_user", "o6-username"))
                 .andDo(print())
                 .andExpect(status().isOk())
@@ -771,7 +771,7 @@ public class GroupingsRestControllerv2_1Test {
         given(membershipService.getNumberOfMemberships(ADMIN, uid))
                 .willReturn(369);
 
-        mockMvc.perform(get(API_BASE + "/groupings/" + uid + "/memberships")
+        mockMvc.perform(get(API_BASE + "/groupings/members/" + uid + "/memberships")
                         .with(csrf())
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
@@ -779,6 +779,20 @@ public class GroupingsRestControllerv2_1Test {
 
         verify(membershipService, times(1))
                 .getNumberOfMemberships(ADMIN, uid);
+    }
+
+    @Test
+    @WithMockUhUser
+    public void isSoleOwnerTest() throws Exception {
+        String uid = "uid";
+        String path = "grouping-path";
+        given(groupingAssignmentService.isSoleOwner(ADMIN, path, uid)).willReturn(true);
+        MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + path + "/owners/" + uid)
+                        .with(csrf())
+                        .header(CURRENT_USER, ADMIN))
+                .andExpect(status().isOk()).andReturn();
+        assertNotNull(mvcResult);
+        verify(groupingAssignmentService, times(1)).isSoleOwner(ADMIN, path, uid);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -140,7 +140,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void adminsGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "adminsGroupings";
+        String url = API_BASE_URL + "admins-and-groupings";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -212,7 +212,7 @@ public class TestGroupingsRestControllerv2_1 {
 
         String url = API_BASE_URL + "groupings/" + GROUPING + "/" +
                 String.join(",", uhNumbersInclude) + "/" +
-                String.join(",", uhNumbersExclude) + "/resetGroup";
+                String.join(",", uhNumbersExclude) + "/reset-group";
 
         MvcResult mvcResult = mockMvc.perform(delete(url)
                         .header(CURRENT_USER, ADMIN)
@@ -264,7 +264,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void getOptInGroupsTest() throws Exception {
-        String url = API_BASE_URL + "groupings/optInGroups/" + TEST_USERNAMES.get(0);
+        String url = API_BASE_URL + "groupings/members/" + TEST_USERNAMES.get(0) + "/opt-in-groups";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -279,7 +279,7 @@ public class TestGroupingsRestControllerv2_1 {
         List<String> iamtst01List = new ArrayList<>();
         iamtst01List.add(TEST_USERNAMES.get(0));
 
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/includeMembers/" + iamtst01List.get(0) + "/self";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/" + iamtst01List.get(0) + "/self";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -297,7 +297,7 @@ public class TestGroupingsRestControllerv2_1 {
         iamtst01List.add(TEST_USERNAMES.get(0));
         membershipService.addIncludeMembers(ADMIN, GROUPING, iamtst01List);
 
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/excludeMembers/" + TEST_USERNAMES.get(0) + "/self";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/" + TEST_USERNAMES.get(0) + "/self";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -310,7 +310,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void addIncludeMembersTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/includeMembers/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/" + String.join(",", TEST_USERNAMES);
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -324,7 +324,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void addExcludeMembersTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/excludeMembers/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/" + String.join(",", TEST_USERNAMES);
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -339,7 +339,7 @@ public class TestGroupingsRestControllerv2_1 {
     @Test
     public void removeIncludeMembersTest() throws Exception {
         membershipService.addIncludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/includeMembers/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/" + String.join(",", TEST_USERNAMES);
         MvcResult mvcResult = mockMvc.perform(delete(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -354,7 +354,7 @@ public class TestGroupingsRestControllerv2_1 {
     @Test
     public void removeExcludeMembersTest() throws Exception {
         membershipService.addExcludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/excludeMembers/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/" + String.join(",", TEST_USERNAMES);
         MvcResult mvcResult = mockMvc.perform(delete(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -425,7 +425,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void enableSyncDestTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/syncDests/" + OPT_IN + "/enable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OPT_IN + "/enable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -438,7 +438,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void disableSyncDestTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/syncDests/" + OPT_IN + "/disable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OPT_IN + "/disable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -451,7 +451,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void enablePreferenceTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/preferences/" + OPT_IN + "/enable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_IN + "/enable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -460,7 +460,7 @@ public class TestGroupingsRestControllerv2_1 {
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
 
-        url = API_BASE_URL + "groupings/" + GROUPING + "/preferences/" + OPT_OUT + "/enable";
+        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_OUT + "/enable";
         mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -469,7 +469,7 @@ public class TestGroupingsRestControllerv2_1 {
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
 
-        url = API_BASE_URL + "groupings/" + GROUPING + "/preferences/" + "badPref" + "/enable";
+        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + "badPref" + "/enable";
         try {
             mockMvc.perform(put(url)
                             .header(CURRENT_USER, ADMIN)
@@ -485,7 +485,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void disablePreferenceTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/preferences/" + OPT_IN + "/disable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_IN + "/disable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -494,7 +494,7 @@ public class TestGroupingsRestControllerv2_1 {
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
 
-        url = API_BASE_URL + "groupings/" + GROUPING + "/preferences/" + OPT_OUT + "/disable";
+        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_OUT + "/disable";
         mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -506,7 +506,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void getSyncDestinationsTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/syncDestinations";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destinations";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -554,7 +554,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void getNumberOfMembershipsTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + TEST_USERNAMES.get(0) + "/memberships";
+        String url = API_BASE_URL + "groupings/members/" + TEST_USERNAMES.get(0) + "/memberships";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -562,6 +562,16 @@ public class TestGroupingsRestControllerv2_1 {
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), Integer.class));
+    }
+
+    @Test
+    public void isSoleOwnerTest() throws Exception {
+        String url = API_BASE_URL + "/groupings/" + GROUPING + "/owners/" + CURRENT_USER;
+        MvcResult mvcResult = mockMvc.perform(get(url)
+                        .header(CURRENT_USER, ADMIN)
+                        .with(user(ADMIN)).with(csrf()))
+                .andExpect(status().isOk()).andReturn();
+        assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
     }
 }
 


### PR DESCRIPTION
**Commits**
- Rename endpoint 'syncDestinations' to 'sync-destinations'.
- Rename endpoint "/groupings/{uid}/memberships" to "/groupings/members/{uid}/memberships".
- Rename endpoint '/groupings/optInGroups/ {uid}' to '/groupings/members/{uid}/opt-in-groups'.
- Rename 'usersToAdd' to 'uids'.
- Rename 'usersToRemove' to 'uids'.
- Rename 'resetGroup' to 'reset-group'.
- Rename "/groupings/{path}/syncDests/{syncDestName}/disable" to  "/groupings/{path}/sync-destination/{id}/disable".
- Rename "/groupings/{path}/syncDests/{syncDestName}/enable" to  "/groupings/{path}/sync-destination/{id}/enable".
- Rename "/groupings/{path}/preferences/{prefenceId}/disable" to  "/groupings/{path}/preference/{id}/disable".
- Rename "/groupings/{path}/preferences/{preferenceId}/enable" to  "/groupings/{path}/preference/{id}/enable".
- Rename 'includeMembers' to 'include-membeers'.
- Rename 'excludeMembers' to 'exclude-members'.
- Rename 'uidToCheck' to 'uid'.
- Rename '/{path:[\\w-:.]+}/owners/{uid}' to  '/groupings/{path:[\\w-:.]+}/owners/{uid}'.
- Rename 'adminsGroupings' to 'admins-and-groupings'.
- Provide unit coverage for *isSoleOwner()* endpoint.
- Provide coverage for *isSoleOwner()* in integrations.
---
[GROUPINGS-1118](https://www.hawaii.edu/jira/browse/GROUPINGS-1118)

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
