### PR TITLE
Refactor return type of optIn/optOut, create addMember function

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -209,7 +209,7 @@ public class GroupingsRestControllerv2_1 {
      * Make a user of uid a member of the include group of grouping at path.
      */
     @PutMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uid:[\\w-:.]+}/self")
-    public ResponseEntity<List<AddMemberResult>> optIn(@RequestHeader(CURRENT_USER) String currentUser,
+    public ResponseEntity<AddMemberResult> optIn(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path, @PathVariable String uid) {
         logger.info("Entered REST optIn...");
         return ResponseEntity
@@ -221,7 +221,7 @@ public class GroupingsRestControllerv2_1 {
      * Make a user of uid a member of the exclude group of grouping at path.
      */
     @PutMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uid:[\\w-:.]+}/self")
-    public ResponseEntity<List<AddMemberResult>> optOut(@RequestHeader(CURRENT_USER) String currentUser,
+    public ResponseEntity<AddMemberResult> optOut(@RequestHeader(CURRENT_USER) String currentUser,
             @PathVariable String path, @PathVariable String uid) {
         logger.info("Entered REST optOut...");
         return ResponseEntity

--- a/src/main/java/edu/hawaii/its/api/service/MembershipService.java
+++ b/src/main/java/edu/hawaii/its/api/service/MembershipService.java
@@ -27,9 +27,9 @@ public interface MembershipService {
 
     List<RemoveMemberResult> removeExcludeMembers(String currentUser, String groupingPath, List<String> usersToRemove);
 
-    List<AddMemberResult> optIn(String currentUser, String groupingPath, String uid);
+    AddMemberResult optIn(String currentUser, String groupingPath, String uid);
 
-    List<AddMemberResult> optOut(String currentUser, String groupingPath, String uid);
+    AddMemberResult optOut(String currentUser, String groupingPath, String uid);
 
     AddMemberResult addAdmin(String currentUser, String adminToAdd);
 
@@ -45,4 +45,6 @@ public interface MembershipService {
     UpdateTimestampResult updateLastModifiedTimestamp(String dateTime, String groupPath);
 
     Integer getNumberOfMemberships(String currentUser, String uid);
+    
+    AddMemberResult addMember(String currentUser, String userToAdd, String removalPath, String additionPath);
 }

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -294,7 +294,8 @@ public class TestGroupingsRestControllerv2_1 {
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn();
-        assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
+        assertNotNull(
+                new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), AddMemberResult.class));
         membershipService.removeIncludeMembers(ADMIN, GROUPING, iamtst01List);
 
     }
@@ -312,7 +313,8 @@ public class TestGroupingsRestControllerv2_1 {
                         .with(csrf()))
                 .andExpect(status().isOk())
                 .andReturn();
-        assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
+        assertNotNull(
+                new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), AddMemberResult.class));
         assertFalse(memberAttributeService.isMember(GROUPING_INCLUDE, iamtst01List.get(0)));
     }
 


### PR DESCRIPTION
# Ticket Link

https://www.hawaii.edu/jira/browse/GROUPINGS-1054

# List of squashed commits

-Implement the helper function addMember into addGroupMembers
-Change optIn and optOut functions to return a single AddMemberResult
-Create addMember function used to add a single user to a group
-Add addMember to interface and change optIn and optOut return types
-Change List.class to AddMemberResult.class in optInTest and optOutTest
-Refactor optInTest and optOutTest and add in addMemberTest

# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
