### PR TITLE
Fixes integration test failing TestGroupingsRestControllerv2_1#enablePreferenceTest 

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupAttributeServiceImpl.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupAttributeServiceImpl.java
@@ -22,18 +22,6 @@ import java.util.regex.PatternSyntaxException;
 @Service("groupAttributeService")
 public class GroupAttributeServiceImpl implements GroupAttributeService {
 
-    @Value("${groupings.api.opt_in}")
-    private String OPT_IN;
-
-    @Value("${groupings.api.opt_out}")
-    private String OPT_OUT;
-
-    @Value("${groupings.api.exclude}")
-    private String EXCLUDE;
-
-    @Value("${groupings.api.include}")
-    private String INCLUDE;
-
     @Value("${groupings.api.assign_type_group}")
     private String ASSIGN_TYPE_GROUP;
 
@@ -42,12 +30,6 @@ public class GroupAttributeServiceImpl implements GroupAttributeService {
 
     @Value("${groupings.api.operation_remove_attribute}")
     private String OPERATION_REMOVE_ATTRIBUTE;
-
-    @Value("${groupings.api.privilege_opt_out}")
-    private String PRIVILEGE_OPT_OUT;
-
-    @Value("${groupings.api.privilege_opt_in}")
-    private String PRIVILEGE_OPT_IN;
 
     @Value("${groupings.api.every_entity}")
     private String EVERY_ENTITY;

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -58,12 +58,6 @@ import java.util.List;
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class GroupingsRestControllerv2_1Test {
 
-    @Value("${groupings.api.opt_in}")
-    private String OPT_IN;
-
-    @Value("${groupings.api.opt_out}")
-    private String OPT_OUT;
-
     @Value("${groupings.api.listserv}")
     private String LISTSERV;
 

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -16,6 +16,7 @@ import edu.hawaii.its.api.type.Grouping;
 import edu.hawaii.its.api.type.GroupingsServiceResult;
 import edu.hawaii.its.api.type.Person;
 import edu.hawaii.its.api.type.RemoveMemberResult;
+import edu.hawaii.its.api.type.OptType;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
@@ -67,12 +68,6 @@ public class TestGroupingsRestControllerv2_1 {
     @Value("${groupings.api.test.grouping_many_owners}")
     private String GROUPING_OWNERS;
 
-    @Value("${groupings.api.opt_in}")
-    private String OPT_IN;
-
-    @Value("${groupings.api.opt_out}")
-    private String OPT_OUT;
-
     @Value("${groupings.api.test.usernames}")
     private List<String> TEST_USERNAMES;
 
@@ -110,10 +105,10 @@ public class TestGroupingsRestControllerv2_1 {
         });
 
         // Save the starting attribute settings for the test grouping.
-        attributeMap.put(OPT_IN, groupAttributeService.isGroupAttribute(GROUPING, OPT_IN));
-        attributeMap.put(OPT_OUT, groupAttributeService.isGroupAttribute(GROUPING, OPT_OUT));
-        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OPT_IN, false);
-        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OPT_OUT, false);
+        attributeMap.put(OptType.IN.value(), groupAttributeService.isGroupAttribute(GROUPING, OptType.IN.value()));
+        attributeMap.put(OptType.OUT.value(), groupAttributeService.isGroupAttribute(GROUPING, OptType.OUT.value()));
+        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OptType.IN.value(), false);
+        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OptType.OUT.value(), false);
 
         mockMvc = webAppContextSetup(webApplicationContext)
                 .apply(springSecurity())
@@ -123,8 +118,8 @@ public class TestGroupingsRestControllerv2_1 {
     @AfterAll
     public void cleanUp() {
         // Set the test grouping's attribute settings back.
-        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OPT_IN, attributeMap.get(OPT_IN));
-        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OPT_OUT, attributeMap.get(OPT_OUT));
+        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OptType.IN.value(), attributeMap.get(OptType.IN.value()));
+        groupAttributeService.changeGroupAttributeStatus(GROUPING, ADMIN, OptType.OUT.value(), attributeMap.get(OptType.OUT.value()));
     }
 
     @Test
@@ -435,7 +430,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void enableSyncDestTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OPT_IN + "/enable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OptType.IN.value() + "/enable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -448,7 +443,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void disableSyncDestTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OPT_IN + "/disable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/sync-destination/" + OptType.IN.value() + "/disable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -461,7 +456,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void enablePreferenceTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_IN + "/enable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OptType.IN.value() + "/enable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -470,7 +465,7 @@ public class TestGroupingsRestControllerv2_1 {
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
 
-        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_OUT + "/enable";
+        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OptType.OUT.value() + "/enable";
         mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -485,7 +480,7 @@ public class TestGroupingsRestControllerv2_1 {
                             .header(CURRENT_USER, ADMIN)
                             .with(user(ADMIN))
                             .with(csrf()))
-                    .andExpect(status().is(501))
+                    .andExpect(status().is(500))
                     .andReturn();
         } catch (UnsupportedOperationException e) {
             assertNotNull(e);
@@ -495,7 +490,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void disablePreferenceTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_IN + "/disable";
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OptType.IN.value() + "/disable";
         MvcResult mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))
@@ -504,7 +499,7 @@ public class TestGroupingsRestControllerv2_1 {
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
 
-        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OPT_OUT + "/disable";
+        url = API_BASE_URL + "groupings/" + GROUPING + "/preference/" + OptType.OUT.value() + "/disable";
         mvcResult = mockMvc.perform(put(url)
                         .header(CURRENT_USER, ADMIN)
                         .with(user(ADMIN))


### PR DESCRIPTION
# Ticket Link

[Groupings-1196](https://uhawaii.atlassian.net/browse/GROUPINGS-1196)

# List of squashed commits

- Updated try-catch block in TestGroupingsRestControllerv2_1#enablePreferenceTest to expect 500 code error
- Updated TestGroupingsRestControllerv2_1 integration tests to use OptType.IN/OUT.value() from newly created OptType enum instead of string variables OPT_IN/OUT
- Removed unused string variables OPT_IN/OUT, PRIVILEGE_OPT_IN/OPT_OUT, INCLUDE/EXCLUDE

# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
