### PR TITLE
[API Side] Changes add/remove member request to contain a body

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -230,9 +230,9 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Add a list of users to the include group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uids}")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/include-members")
     public ResponseEntity<List<AddMemberResult>> addIncludeMembers(@RequestHeader(CURRENT_USER) String currentUser,
-            @PathVariable String path, @PathVariable List<String> uids) {
+            @PathVariable String path, @RequestBody List<String> uids) {
         logger.info("Entered REST addIncludeMembers...");
         return ResponseEntity
                 .ok()
@@ -242,9 +242,9 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Add a list of users to the exclude group of grouping at path.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uids}")
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members")
     public ResponseEntity<List<AddMemberResult>> addExcludeMembers(@RequestHeader(CURRENT_USER) String currentUser,
-            @PathVariable String path, @PathVariable List<String> uids) {
+            @PathVariable String path, @RequestBody List<String> uids) {
         logger.info("Entered REST addExcludeMembers...");
         return ResponseEntity
                 .ok()
@@ -254,10 +254,10 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Remove a list of users from the include group of grouping at path.
      */
-    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/include-members/{uids}")
+    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/include-members")
     public ResponseEntity<List<RemoveMemberResult>> removeIncludeMembers(
             @RequestHeader(CURRENT_USER) String currentUser, @PathVariable String path,
-            @PathVariable List<String> uids) {
+            @RequestBody List<String> uids) {
         logger.info("Entered REST removeIncludeMembers...");
         return ResponseEntity
                 .ok()
@@ -267,10 +267,10 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Remove a list of users from the exclude include group of grouping at path.
      */
-    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members/{uids}")
+    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/exclude-members")
     public ResponseEntity<List<RemoveMemberResult>> removeExcludeMembers(
             @RequestHeader(CURRENT_USER) String currentUser, @PathVariable String path,
-            @PathVariable List<String> uids) {
+            @RequestBody List<String> uids) {
         logger.info("Entered REST removeExcludeMembers...");
         return ResponseEntity
                 .ok()

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -24,6 +24,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
@@ -46,6 +47,7 @@ import edu.hawaii.its.api.type.Person;
 import edu.hawaii.its.api.type.PrivilegeType;
 import edu.hawaii.its.api.type.RemoveMemberResult;
 import edu.hawaii.its.api.type.SyncDestination;
+import edu.hawaii.its.api.util.JsonUtil;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -388,8 +390,10 @@ public class GroupingsRestControllerv2_1Test {
         usersToAdd.add("tst06name");
         given(membershipService.addIncludeMembers(USERNAME, "grouping", usersToAdd))
                 .willReturn(addMemberResults);
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/include-members/" + String.join(",", usersToAdd))
-                .header(CURRENT_USER, USERNAME))
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/include-members/")
+                .header(CURRENT_USER, USERNAME)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToAdd)))
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))
@@ -406,8 +410,10 @@ public class GroupingsRestControllerv2_1Test {
         given(membershipService.addExcludeMembers(USERNAME, "grouping", usersToAdd))
                 .willReturn(addMemberResults);
 
-        mockMvc.perform(put(API_BASE + "/groupings/grouping/exclude-members/" + String.join(",", usersToAdd))
-                .header(CURRENT_USER, USERNAME))
+        mockMvc.perform(put(API_BASE + "/groupings/grouping/exclude-members/")
+                .header(CURRENT_USER, USERNAME)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToAdd)))
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))
@@ -423,8 +429,10 @@ public class GroupingsRestControllerv2_1Test {
         usersToRemove.add("tst06name");
         given(membershipService.removeIncludeMembers(USERNAME, "grouping", usersToRemove))
                 .willReturn(removeMemberResults);
-        mockMvc.perform(delete(API_BASE + "/groupings/grouping/include-members/" + String.join(",", usersToRemove))
-                .header(CURRENT_USER, USERNAME))
+        mockMvc.perform(delete(API_BASE + "/groupings/grouping/include-members/")
+                .header(CURRENT_USER, USERNAME)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToRemove)))
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))
@@ -440,8 +448,10 @@ public class GroupingsRestControllerv2_1Test {
         usersToRemove.add("tst06name");
         given(membershipService.removeExcludeMembers(USERNAME, "grouping", usersToRemove))
                 .willReturn(removeMemberResults);
-        mockMvc.perform(delete(API_BASE + "/groupings/grouping/exclude-members/" + String.join(",", usersToRemove))
-                .header(CURRENT_USER, USERNAME))
+        mockMvc.perform(delete(API_BASE + "/groupings/grouping/exclude-members/")
+                .header(CURRENT_USER, USERNAME)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(usersToRemove)))
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -17,10 +17,12 @@ import edu.hawaii.its.api.type.GroupingsServiceResult;
 import edu.hawaii.its.api.type.Person;
 import edu.hawaii.its.api.type.RemoveMemberResult;
 import edu.hawaii.its.api.type.OptType;
+import edu.hawaii.its.api.util.JsonUtil;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -284,9 +286,11 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void addIncludeMembersTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/";
         MvcResult mvcResult = mockMvc.perform(put(url)
-                        .header(CURRENT_USER, ADMIN))
+                        .header(CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(TEST_USERNAMES)))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
@@ -296,9 +300,11 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void addExcludeMembersTest() throws Exception {
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/";
         MvcResult mvcResult = mockMvc.perform(put(url)
-                        .header(CURRENT_USER, ADMIN))
+                        .header(CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(TEST_USERNAMES)))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
@@ -309,9 +315,11 @@ public class TestGroupingsRestControllerv2_1 {
     @Test
     public void removeIncludeMembersTest() throws Exception {
         membershipService.addIncludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/";
         MvcResult mvcResult = mockMvc.perform(delete(url)
-                        .header(CURRENT_USER, ADMIN))
+                        .header(CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(TEST_USERNAMES)))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));
@@ -322,9 +330,11 @@ public class TestGroupingsRestControllerv2_1 {
     @Test
     public void removeExcludeMembersTest() throws Exception {
         membershipService.addExcludeMembers(ADMIN, GROUPING, TEST_USERNAMES);
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/" + String.join(",", TEST_USERNAMES);
+        String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/";
         MvcResult mvcResult = mockMvc.perform(delete(url)
-                        .header(CURRENT_USER, ADMIN))
+                        .header(CURRENT_USER, ADMIN)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(JsonUtil.asJson(TEST_USERNAMES)))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(new ObjectMapper().readValue(mvcResult.getResponse().getContentAsByteArray(), List.class));


### PR DESCRIPTION
# Ticket Link

[Groupings-1214](https://uhawaii.atlassian.net/browse/GROUPINGS-1214)

# List of squashed commits

- Changed GroupingsRestController to expect a PUT request with a body instead of a header in add member functions
- Updated unit and integration tests

# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
