### PR TITLE
Addresses Dependabot Alert: Bump bcprov-jdk15on from 1.60 to 1.67

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
         <java.version>1.8</java.version>
         <junit.version>4.13.1</junit.version>
-        <org.jasig.cas.client-version>3.6.0</org.jasig.cas.client-version>
+        <org.jasig.cas.client-version>3.6.4</org.jasig.cas.client-version>
 
         <swagger2markup.version>1.2.0</swagger2markup.version>
         <asciidoctor.input.directory>${project.basedir}/src/docs/asciidoc</asciidoctor.input.directory>
@@ -186,11 +186,6 @@
         </dependency>
 
         <!-- Overrides Spring's innate dependencies with updated versions -->
-        <dependency>
-            <groupId>org.bouncycastle</groupId>
-            <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.60</version>
-        </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>


### PR DESCRIPTION
# Ticket Link

[Groupings-1122](https://uhawaii.atlassian.net/browse/GROUPINGS-1122)

# List of squashed commits

- Removed Bouncy Castle dependency, updated Jasig cas-client-core to update Bouncy Castle instead

# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
