### PR TITLE
Remove sync_destinations from properties files

### DIFF
--- a/src/main/resources/application-localTest.properties
+++ b/src/main/resources/application-localTest.properties
@@ -32,8 +32,6 @@ groupings.api.test.grouping_single_include=${groupings.api.test.grouping_single}
 groupings.api.test.grouping_single_exclude=${groupings.api.test.grouping_single}${groupings.api.exclude}
 groupings.api.test.grouping_single_owners=${groupings.api.test.grouping_single}${groupings.api.owners}
 
-groupings.api.test.sync_destinations=test-sync-destination01,test-sync-destination02,test-sync-destination03
-
 groupings.api.test.username=username
 groupings.api.test.name=name
 groupings.api.test.uhuuid=uhuuid

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -79,6 +79,3 @@ groupings.api.documentation.license.url=API license URL (replace me)
 # OpenAPI 3 Swagger UI Settings (https://springdoc.org/properties.html)
 springdoc.swagger-ui.displayOperationId=true
 springdoc.swagger-ui.displayRequestDuration=true
-# Test
-groupings.api.test.sync_destinations=test-sync-destination01,test-sync-destination02,test-sync-destination03
-# SMTP


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1218](https://uhawaii.atlassian.net/browse/GROUPINGS-1218)

# List of squashed commits

- Removes test.sync_destinations
- Removed test.sync_destinations from application.properties and application-localTest.properties
- Small formatting fix

# Test Checklist

- [X] Unit Tests Passed:
- [X] Integration Tests Passed:
- [X] General Visual Inspection:
