### PR TITLE
Fixes and creates tests for no everyone-can-opt-in scenario

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupPathService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupPathService.java
@@ -73,9 +73,6 @@ public class GroupPathService {
     }
 
     public List<Group> getValidGroupings(List<String> groupingPaths) {
-        if (groupingPaths.isEmpty()) {
-            return new ArrayList<>();
-        }
         return grouperApiService.findGroupsResults(groupingPaths).getGroups();
     }
 

--- a/src/main/java/edu/hawaii/its/api/wrapper/FindGroupsCommand.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/FindGroupsCommand.java
@@ -29,6 +29,9 @@ public class FindGroupsCommand extends GrouperCommand implements Command<FindGro
     }
 
     public FindGroupsCommand addPaths(List<String> paths) {
+        if (paths.isEmpty()) {
+            addPath("");
+        }
         for (String path : paths) {
             addPath(path);
         }

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupPathService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupPathService.java
@@ -11,7 +11,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -143,6 +144,12 @@ public class TestGroupPathService {
     }
 
     @Test
+    public void getValidGroupings() {
+        List<String> groupingPaths = Arrays.asList(GROUPING);
+        assertEquals(GROUPING, groupPathService.getValidGroupings(groupingPaths).get(0).getGroupPath());
+    }
+
+    @Test
     public void getIncludeGroup() {
         assertEquals(GROUPING_INCLUDE, groupPathService.getIncludeGroup(GROUPING));
         assertEquals(GROUPING_INCLUDE, groupPathService.getIncludeGroup(GROUPING_INCLUDE));
@@ -183,14 +190,11 @@ public class TestGroupPathService {
     }
 
     @Test
-    public void getValidGroupingsTest() {
-        ArrayList<String> emptyList = new ArrayList<>();
-        ArrayList<String> inputList = new ArrayList<>();
-        inputList.add(GROUPING);
-
-        assertEquals(emptyList, groupPathService.getValidGroupings(emptyList));
-        assertNotNull(groupPathService.getValidGroupings(inputList));
-
+    public void getGroupPaths() {
+        List<String> groupPaths = groupPathService.getGroupPaths(GROUPING);
+        assertTrue(groupPaths.contains(GROUPING_BASIS));
+        assertTrue(groupPaths.contains(GROUPING_INCLUDE));
+        assertTrue(groupPaths.contains(GROUPING_EXCLUDE));
+        assertTrue(groupPaths.contains(GROUPING_OWNERS));
     }
-
 }

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
@@ -17,6 +17,7 @@ import edu.hawaii.its.api.type.Person;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.core.env.Environment;
 import org.springframework.test.context.ActiveProfiles;
 
@@ -35,6 +36,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.BDDMockito.given;
 
 @ActiveProfiles("integrationTest")
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
@@ -80,13 +82,13 @@ public class TestGroupingAssignmentService {
     GroupingAssignmentService groupingAssignmentService;
 
     @Autowired
-    private MembershipService membershipService;
-
-    @Autowired
     MemberAttributeService memberAttributeService;
 
     @Autowired
     GrouperApiService grouperApiService;
+
+    @SpyBean
+    GroupingsService groupingsService;
 
     @Autowired private UpdateMemberService updateMemberService;
 
@@ -324,6 +326,14 @@ public class TestGroupingAssignmentService {
             assertTrue(groupingAttributeService.isGroupAttribute(path, OptType.OUT.value()));
         });
 
+    }
+
+    @Test
+    public void noOptInGroupingsPathsTest() {
+        given(groupingsService.optInEnabledGroupingPaths()).willReturn(Collections.emptyList());
+        List<GroupingPath> optInGroupingsPaths =
+                groupingAssignmentService.optInGroupingPaths(ADMIN, testPerson.getUsername());
+        assertEquals(Collections.emptyList(), optInGroupingsPaths);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/wrapper/FindGroupsCommandTest.java
+++ b/src/test/java/edu/hawaii/its/api/wrapper/FindGroupsCommandTest.java
@@ -21,5 +21,6 @@ public class FindGroupsCommandTest {
         strings.add("");
         assertNotNull(findGroupsCommand.addPath(""));
         assertNotNull(findGroupsCommand.addPaths(strings));
+        assertNotNull(findGroupsCommand.addPaths(new ArrayList<>()));
     }
 }


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1256](https://uhawaii.atlassian.net/browse/GROUPINGS-1256)

# List of squashed commits

- Removed isEmpty() guard from GroupPathService#getValidGroupings, put isEmpty() guard for FindGroupsCommand#addPaths
- Increased test coverage for FindGroupsCommand and GroupPathService
- Fixed Codacy issues

# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
