### PR TITLE
Remove unused yearOfDate() function in util/Dates.java

### DIFF
--- a/src/main/java/edu/hawaii/its/api/util/Dates.java
+++ b/src/main/java/edu/hawaii/its/api/util/Dates.java
@@ -142,10 +142,6 @@ public final class Dates {
         return LocalDate.now().getYear();
     }
 
-    public static int yearOfDate(LocalDate date) {
-        return date.getYear();
-    }
-
     public static DayOfWeek dayOfWeek(LocalDate date) {
         return date.getDayOfWeek();
     }

--- a/src/test/java/edu/hawaii/its/api/util/DatesTest.java
+++ b/src/test/java/edu/hawaii/its/api/util/DatesTest.java
@@ -503,15 +503,6 @@ public class DatesTest {
     }
 
     @Test
-    public void yearOfDate() {
-        for (int year = 2000; year < 2050; year++) {
-            assertThat(Dates.yearOfDate(Dates.firstDateOfYear(year)), is(year));
-            assertThat(Dates.yearOfDate(Dates.lastDateOfYear(year)), is(year));
-            assertThat(Dates.yearOfDate(Dates.lastDateOfMonth(Month.FEBRUARY, year)), is(year));
-        }
-    }
-
-    @Test
     public void dayOfWeek() {
         LocalDate lod = Dates.toLocalDate(Dates.toDate(Dates.firstDateOfYear(2012)));
         for (int i = 0; i < 366; i++) {


### PR DESCRIPTION
# Ticket Link

[Ticket 1498](https://uhawaii.atlassian.net/browse/GROUPINGS-1498)

# List of squashed commits

- Commit 1:Remove unused yearOfDate() function in util/Dates.java


# Test Checklist

- [x] Unit Tests Passed:
- [x] Integration Tests Passed:
- [x] General Visual Inspection:
