### PR TITLE
Implement the "announcements" attributes from Grouper

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -35,6 +35,7 @@ import edu.hawaii.its.api.groupings.GroupingRemoveResults;
 import edu.hawaii.its.api.groupings.GroupingReplaceGroupMembersResult;
 import edu.hawaii.its.api.groupings.GroupingSyncDestinations;
 import edu.hawaii.its.api.groupings.GroupingUpdateDescriptionResult;
+import edu.hawaii.its.api.service.AnnouncementsService;
 import edu.hawaii.its.api.service.AsyncJobsManager;
 import edu.hawaii.its.api.service.GroupingAssignmentService;
 import edu.hawaii.its.api.service.GroupingAttributeService;
@@ -86,6 +87,9 @@ public class GroupingsRestControllerv2_1 {
 
     @Autowired
     private GroupingOwnerService groupingOwnerService;
+
+    @Autowired
+    private AnnouncementsService announcementsService;
 
     final private static String CURRENT_USER_KEY = "current_user";
 
@@ -660,5 +664,16 @@ public class GroupingsRestControllerv2_1 {
         return ResponseEntity
                 .ok()
                 .body(asyncJobsManager.getJobResult(currentUser, jobId));
+    }
+
+    /**
+     * Get the list of active announcements to display.
+     */
+    @GetMapping(value = "/announcements/active")
+    public ResponseEntity activeAnnouncements() {
+        logger.info("Entered REST activeAnnouncements...");
+        return ResponseEntity
+                .ok()
+                .body(announcementsService.activeAnnouncements());
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/AnnouncementsService.java
+++ b/src/main/java/edu/hawaii/its/api/service/AnnouncementsService.java
@@ -1,0 +1,44 @@
+package edu.hawaii.its.api.service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import edu.hawaii.its.api.type.Announcement;
+import edu.hawaii.its.api.type.Announcements;
+import edu.hawaii.its.api.util.JsonUtil;
+import edu.hawaii.its.api.wrapper.AttributesResult;
+import edu.hawaii.its.api.wrapper.FindAttributesResults;
+
+@Service
+public class AnnouncementsService {
+    public static final Log log = LogFactory.getLog(AnnouncementsService.class);
+
+    @Value("${groupings.api.announcements}")
+    private String ANNOUNCEMENTS_ATTR_NAME;
+
+    @Value("${groupings.api.propertystring}")
+    private String ANNOUNCEMENTS_ATTR_DEF;
+
+    @Autowired
+    private GrouperApiService grouperApiService;
+
+    public Announcements setAnnouncements(AttributesResult attributesResult) {
+        List<Announcement> announcementsList = new ArrayList<>();
+        announcementsList = JsonUtil.asList(attributesResult.getDescription(), Announcement.class);
+        return new Announcements(announcementsList);
+    }
+
+    public List<String> activeAnnouncements() {
+        FindAttributesResults findAttributesResults = grouperApiService.findAttributesResults(
+                ANNOUNCEMENTS_ATTR_DEF,
+                ANNOUNCEMENTS_ATTR_NAME);
+        Announcements activeAnnouncements = setAnnouncements(findAttributesResults.getResult());
+        return activeAnnouncements.validMessages(activeAnnouncements.getAnnouncements());
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/type/Announcement.java
+++ b/src/main/java/edu/hawaii/its/api/type/Announcement.java
@@ -1,0 +1,70 @@
+package edu.hawaii.its.api.type;
+
+import java.time.LocalDateTime;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+
+
+public class Announcement {
+    private String message = "";
+    private State state;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(pattern = "yyyyMMdd'T'HHmmss")
+    private LocalDateTime start;
+
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
+    @JsonFormat(pattern = "yyyyMMdd'T'HHmmss")
+    private LocalDateTime end;
+
+    public enum State {
+        Active,
+        Expired,
+        Future
+    }
+
+    Announcement(@JsonProperty("message") String message,
+                 @JsonProperty("start") LocalDateTime start,
+                 @JsonProperty("end") LocalDateTime end) {
+        this.message = message;
+        this.start = start;
+        this.end = end;
+
+        LocalDateTime currDate = LocalDateTime.now();
+        if (start.isBefore(currDate) && end.isAfter(currDate)) {
+            state = State.Active;
+        } else if (start.isAfter(currDate)) {
+            state = State.Future;
+        } else {
+            state = State.Expired;
+        }
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public LocalDateTime getStart() {
+        return start;
+    }
+
+    public LocalDateTime getEnd() {
+        return end;
+    }
+
+    public State getState() {
+        return state;
+    }
+
+    @Override
+    public String toString() {
+        return "Announcement [" +
+                "message='" + message + '\'' +
+                ", start='" + start + '\'' +
+                ", end='" + end + '\'' +
+                "]";
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/type/Announcements.java
+++ b/src/main/java/edu/hawaii/its/api/type/Announcements.java
@@ -1,0 +1,45 @@
+package edu.hawaii.its.api.type;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+@Service
+public class Announcements {
+    private String resultCode;
+    private List<Announcement> announcements = new ArrayList<>();
+
+    public Announcements(List<Announcement> announcements) {
+        if (announcements != null) {
+            for (Announcement a : announcements) {
+                this.announcements.add(a);
+            }
+            setResultCode("SUCCESS");
+        }
+    }
+
+    public Announcements() {
+        setResultCode("FAILURE");
+    }
+
+    private void setResultCode(String resultCode) {
+        this.resultCode = resultCode;
+    }
+
+    public List<Announcement> getAnnouncements() {
+        return announcements;
+    }
+    public String getResultCode() {
+        return resultCode;
+    }
+
+    public List<String> validMessages(List<Announcement> allGroupingsAnnouncements) {
+        List<String> validMessages = new ArrayList<>();
+        for (Announcement groupingsAnnouncement : allGroupingsAnnouncements) {
+            if (groupingsAnnouncement.getState() == Announcement.State.Active) {
+                validMessages.add(groupingsAnnouncement.getMessage());
+            }
+        }
+        return validMessages;
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
@@ -1,8 +1,8 @@
 package edu.hawaii.its.api.util;
 
+import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonUtil {
@@ -19,7 +19,6 @@ public class JsonUtil {
             result = new ObjectMapper().writeValueAsString(obj);
         } catch (Exception e) {
             logger.error("Error: " + e);
-            // Maybe we should throw something?
         }
         return result;
     }
@@ -30,7 +29,17 @@ public class JsonUtil {
             result = new ObjectMapper().readValue(json, type);
         } catch (Exception e) {
             logger.error("Error: " + e);
-            // Maybe we should throw something?
+        }
+        return result;
+    }
+
+    public static <T> List<T> asList(final String json, Class<T> type) {
+        List<T> result = null;
+        try {
+            ObjectMapper mapper = new ObjectMapper();
+            result = mapper.readValue(json, mapper.getTypeFactory().constructCollectionType(List.class, type));
+        } catch (Exception e) {
+            logger.error("Error: " + e);
         }
         return result;
     }

--- a/src/main/java/edu/hawaii/its/api/wrapper/FindAttributesResults.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/FindAttributesResults.java
@@ -2,7 +2,6 @@ package edu.hawaii.its.api.wrapper;
 
 import java.util.ArrayList;
 import java.util.List;
-
 import edu.internet2.middleware.grouperClient.ws.beans.WsAttributeDefName;
 import edu.internet2.middleware.grouperClient.ws.beans.WsFindAttributeDefNamesResults;
 
@@ -22,6 +21,14 @@ public class FindAttributesResults extends Results {
             return "FAILURE";
         }
         return this.wsFindAttributeDefNamesResults.getResultMetadata().getResultCode();
+    }
+
+    public AttributesResult getResult() {
+        WsAttributeDefName[] wsAttributeDefNames = this.wsFindAttributeDefNamesResults.getAttributeDefNameResults();
+        if (isEmpty(wsAttributeDefNames)) {
+            return new AttributesResult();
+        }
+        return new AttributesResult(wsAttributeDefNames[0]);
     }
 
     public List<AttributesResult> getResults() {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -25,11 +25,17 @@ groupings.api.grouping_admins=${groupings.api.settings}:groupingAdmins
 groupings.api.grouping_apps=${groupings.api.settings}:groupingApps
 groupings.api.grouping_owners=${groupings.api.settings}:groupingOwners
 groupings.api.attributes=${groupings.api.settings}:attributes
+groupings.api.for_applications=${groupings.api.attributes}:for-applications
 groupings.api.for_groups=${groupings.api.attributes}:for-groups
 groupings.api.for_memberships=${groupings.api.attributes}:for-memberships
 groupings.api.last_modified=${groupings.api.for_groups}:last-modified
 groupings.api.yyyymmddThhmm=${groupings.api.last_modified}:yyyymmddThhmm
 groupings.api.uhgrouping=${groupings.api.for_groups}:uh-grouping
+
+groupings.api.uhgroupings=${groupings.api.for_applications}:uhgroupings
+groupings.api.announcements=${groupings.api.uhgroupings}:announcements
+groupings.api.propertystring=${groupings.api.uhgroupings}:propertyString
+
 groupings.api.destinations=${groupings.api.uhgrouping}:destinations
 groupings.api.listserv=${groupings.api.destinations}:listserv
 groupings.api.releasedgrouping=${groupings.api.destinations}:uhReleasedGrouping

--- a/src/test/java/edu/hawaii/its/api/service/TestAnnouncementsService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestAnnouncementsService.java
@@ -1,0 +1,54 @@
+package edu.hawaii.its.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.type.Announcements;
+import edu.hawaii.its.api.wrapper.FindAttributesResults;
+
+@ActiveProfiles("integrationTest")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+public class TestAnnouncementsService {
+    @Value("${groupings.api.announcements}")
+    private String ANNOUNCEMENTS_ATTR_NAME;
+    @Value("${groupings.api.propertystring}")
+    private String ANNOUNCEMENTS_ATTR_DEF;
+    @Value("${groupings.api.success}")
+    private String SUCCESS;
+    @Autowired
+    private AnnouncementsService announcementsService;
+    @Autowired
+    private GrouperApiService grouperApiService;
+
+    @Test
+    public void setAnnouncements() {
+        FindAttributesResults findAttributesResults = grouperApiService.findAttributesResults(
+                ANNOUNCEMENTS_ATTR_DEF,
+                ANNOUNCEMENTS_ATTR_NAME);
+        assertNotNull(findAttributesResults.getResults());
+        Announcements results = announcementsService.setAnnouncements(findAttributesResults.getResult());
+        assertNotNull(results);
+        assertNotNull(results.getAnnouncements());
+        assertEquals(SUCCESS, results.getResultCode());
+    }
+
+    @Test
+    public void activeAnnouncements() {
+        List<String> results = announcementsService.activeAnnouncements();
+        // Only when Grouper has this case specific data (will need to keep updating).
+        assertNotNull(results);
+        assertEquals("first valid message", results.get(0));
+        assertEquals("second valid message", results.get(1));
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/type/AnnouncementTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/AnnouncementTest.java
@@ -1,0 +1,54 @@
+package edu.hawaii.its.api.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class AnnouncementTest {
+    private Announcement expiredAnnouncement;
+    private Announcement activeAnnouncement;
+    private Announcement futureAnnouncement;
+
+    @BeforeEach
+    void setUp() {
+        // Expired - start and end date is before the current local date time.
+        LocalDateTime start1 = LocalDateTime.parse("2023-06-07T00:00");
+        LocalDateTime end1 = LocalDateTime.parse("2023-06-15T00:00");
+        expiredAnnouncement = new Announcement("expired message", start1, end1);
+        // Valid - start date is before the current local date time and end date is after the current local date time.
+        LocalDateTime start2 = LocalDateTime.parse("2023-11-07T00:00");
+        LocalDateTime end2 = LocalDateTime.parse("2023-12-25T00:00");
+        activeAnnouncement = new Announcement("valid message", start2, end2);
+        // Future - start and date is after the current local date time.
+        LocalDateTime start3 = LocalDateTime.parse("2023-12-30T00:00");
+        LocalDateTime end3 = LocalDateTime.parse("2024-01-25T00:00");
+        futureAnnouncement = new Announcement("future message", start3, end3);
+    }
+
+    @Test
+    void accessors() {
+        assertNotNull(expiredAnnouncement);
+        assertNotNull(activeAnnouncement);
+        assertNotNull(futureAnnouncement);
+
+        assertEquals("expired message", expiredAnnouncement.getMessage());
+        assertEquals("valid message", activeAnnouncement.getMessage());
+        assertEquals("future message", futureAnnouncement.getMessage());
+
+        assertEquals(LocalDateTime.parse("2023-06-07T00:00"), expiredAnnouncement.getStart());
+        assertEquals(LocalDateTime.parse("2023-11-07T00:00"), activeAnnouncement.getStart());
+        assertEquals(LocalDateTime.parse("2023-12-30T00:00"), futureAnnouncement.getStart());
+
+        assertEquals(LocalDateTime.parse("2023-06-15T00:00"), expiredAnnouncement.getEnd());
+        assertEquals(LocalDateTime.parse("2023-12-25T00:00"), activeAnnouncement.getEnd());
+        assertEquals(LocalDateTime.parse("2024-01-25T00:00"), futureAnnouncement.getEnd());
+
+        assertEquals(Announcement.State.Expired, expiredAnnouncement.getState());
+        assertEquals(Announcement.State.Active, activeAnnouncement.getState());
+        assertEquals(Announcement.State.Future, futureAnnouncement.getState());
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/type/AnnouncementsTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/AnnouncementsTest.java
@@ -1,0 +1,65 @@
+package edu.hawaii.its.api.type;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+class AnnouncementsTest {
+    private Announcements emptyAnnouncements;
+    private Announcements announcements;
+    private List<Announcement> announcementsList;
+
+    @BeforeEach
+    void setUp() {
+        emptyAnnouncements = new Announcements();
+        announcementsList = new ArrayList<>();
+
+        LocalDateTime start1 = LocalDateTime.parse("2023-06-07T00:00");
+        LocalDateTime end1 = LocalDateTime.parse("2023-06-15T00:00");
+        LocalDateTime start2 = LocalDateTime.parse("2023-12-06T00:00");
+        LocalDateTime end2 = LocalDateTime.parse("2023-12-08T00:00");
+        LocalDateTime start3 = LocalDateTime.parse("2023-12-08T00:00");
+        LocalDateTime end3 = LocalDateTime.parse("2024-02-15T00:00");
+
+        announcementsList.add(new Announcement("old message", start1, end1));
+        announcementsList.add(new Announcement("Test will be down for migration to new VMs featuring Java 17 (required for Spring Boot 3)", start2, end2));
+        announcementsList.add(new Announcement("Test is now running on VMs featuring Java 17 (hello Spring Boot3)", start3, end3));
+        announcements = new Announcements(announcementsList);
+    }
+
+    @Test
+    void accessors() {
+        // Constructed with no parameters, an empty and invalid Announcements object.
+        assertNotNull(emptyAnnouncements);
+        assertEquals(new ArrayList<>(), emptyAnnouncements.getAnnouncements());
+        assertEquals("FAILURE", emptyAnnouncements.getResultCode());
+
+        // Constructed with parameters, a valid Announcements object.
+        assertNotNull(announcements);
+        assertEquals(announcementsList, announcements.getAnnouncements());
+        assertEquals("SUCCESS", announcements.getResultCode());
+    }
+
+    @Test
+    void validMessages() {
+        // Returns a List<String> object when constructed empty.
+        assertNotNull(announcements.validMessages(announcementsList));
+
+        // Returns one valid message.
+        List<String> expectedMessages = new ArrayList<>();
+        expectedMessages.add("Test is now running on VMs featuring Java 17 (hello Spring Boot3)");
+        assertEquals(expectedMessages, announcements.validMessages(announcementsList));
+
+        // Returns all valid messages.
+        LocalDateTime start4 = LocalDateTime.parse("2023-01-15T00:00");
+        LocalDateTime end4 = LocalDateTime.parse("2024-01-25T00:00");
+        announcementsList.add(new Announcement("second valid message", start4, end4));
+        expectedMessages.add("second valid message");
+        assertEquals(expectedMessages, announcements.validMessages(announcementsList));
+    }
+}


### PR DESCRIPTION
# Ticket Link

[Ticket 1532](https://uhawaii.atlassian.net/browse/GROUPINGS-1532)

# List of squashed commits

- Two containers but logo offset
- Create GroupingsAnnouncement.java and GroupingsAnnouncements.java
- Saving progress
- Commit to pull from main
- Logic correct
- Created asObjectList method for JsonUtil
- Reorganize Announcements
- Revert "Created asObjectList method for JsonUtil"
- This reverts commit https://github.com/uhawaii-system-its-ti-iam/uh-groupingsapi/commit/1257ec8fdad39e2cac5525743dcdd010537528e6.
- Get announcement object to show as null on site
- All announcements show on browser
- Implement date comparisons, need new test data
- Get rid of user param
- Create helper methods in Announcement
- Delete PlannedOutage files
- Clean up code
- Start integration testing
- Whole response body display on site (resultCode and announcements)
- Display one valid message and clean up code
- No other errors other than currentUser
- Clean up code
- Convert to showing all Active messages
- Clean up code and rename functions
- Add integration test and encapsulate Grouper attr paths
- Clean up imports
- Unit test for the Announcements obj
- Unit test for Announcement
- Clean up code and fix tests
- Merge conflicts again
- Address pr suggestions
- Get rid of Codacy unused imports
- Undo renaming files
- Address Github feedback
- Get rid of redundant findAnnouncements call in Announcements.java
- Get rid of findAnnouncements altogether for Codacy
- Change setAnnouncements() to use getResult instead of getResults
- Address Github feedback
- Get rid of EmailService changes
- Fix import order
- Codacy unused variable
- Imports
- Update email service files to match project's main
- Rebranched
- Fix comments and imports
- Fix import order
- Update AnnouncementsTest with new data

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
