### PR TITLE
Create a standard failure object for the API to hand back to the UI project

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/ForTestingRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/ForTestingRestController.java
@@ -1,5 +1,6 @@
 package edu.hawaii.its.api.controller;
 
+import edu.hawaii.its.api.type.ApiValidationError;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.http.ResponseEntity;
@@ -12,14 +13,17 @@ import edu.hawaii.its.api.exception.ExceptionForTesting;
 
 @RestController
 @RequestMapping("/api/groupings/v2.1/testing")
-public class GroupingsRestControllerv2_1ForTesting {
+public class ForTestingRestController {
 
-    private static final Log logger = LogFactory.getLog(GroupingsRestControllerv2_1ForTesting.class);
+    private static final Log logger = LogFactory.getLog(ForTestingRestController.class);
 
     @GetMapping(value = "/exception")
     @ResponseBody
     public ResponseEntity throwException() {
         logger.debug("Entered REST throwException");
-        throw new ExceptionForTesting("Test exception");
+            ExceptionForTesting exception = new ExceptionForTesting("Exception for test failed")
+                .addSubError(new ApiValidationError("testing object 1", "membership service", "id: 12", "Membership access denied"))
+                .addSubError(new ApiValidationError("testing object 2", "member service", "id: 30", "There is no member"));
+        throw exception;
     }
 }

--- a/src/main/java/edu/hawaii/its/api/exception/ExceptionForTesting.java
+++ b/src/main/java/edu/hawaii/its/api/exception/ExceptionForTesting.java
@@ -1,7 +1,25 @@
 package edu.hawaii.its.api.exception;
 
+import edu.hawaii.its.api.type.ApiSubError;
+
+import java.util.ArrayList;
+import java.util.List;
+
 public class ExceptionForTesting extends RuntimeException {
+
+    private List<ApiSubError> subErrors;
+
     public ExceptionForTesting(String message) {
         super(message);
+        this.subErrors = new ArrayList<>();
+    }
+
+    public List<ApiSubError> getSubErrors() {
+        return subErrors;
+    }
+
+    public ExceptionForTesting addSubError(ApiSubError subError) {
+        this.subErrors.add(subError);
+        return this;
     }
 }

--- a/src/main/java/edu/hawaii/its/api/exception/UhMemberNotFoundException.java
+++ b/src/main/java/edu/hawaii/its/api/exception/UhMemberNotFoundException.java
@@ -1,12 +1,27 @@
 package edu.hawaii.its.api.exception;
 
+import edu.hawaii.its.api.type.ApiSubError;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class UhMemberNotFoundException extends ResponseStatusException {
 
+    private final List<ApiSubError> subErrors;
     public UhMemberNotFoundException(String reason) {
         super(HttpStatus.NOT_FOUND, reason);
+        this.subErrors = new ArrayList<>();
+    }
+
+    public List<ApiSubError> getSubErrors() {
+        return subErrors;
+    }
+
+    public UhMemberNotFoundException addSubError(ApiSubError subError) {
+        this.subErrors.add(subError);
+        return this;
     }
 
 }

--- a/src/main/java/edu/hawaii/its/api/service/ExecutorService.java
+++ b/src/main/java/edu/hawaii/its/api/service/ExecutorService.java
@@ -22,5 +22,4 @@ public class ExecutorService {
         }
         return result;
     }
-
 }

--- a/src/main/java/edu/hawaii/its/api/type/ApiError.java
+++ b/src/main/java/edu/hawaii/its/api/type/ApiError.java
@@ -1,0 +1,95 @@
+package edu.hawaii.its.api.type;
+
+import org.springframework.http.HttpStatus;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+public class ApiError {
+
+    private final HttpStatus status;
+    private final LocalDateTime timestamp;
+    private final String message;
+    private final String debugMessage;
+    private final List<ApiSubError> subErrors;
+
+    private ApiError(Builder builder) {
+        this.status = builder.status;
+        this.timestamp = builder.timestamp != null ? builder.timestamp : LocalDateTime.now();
+        this.message = builder.message;
+        this.debugMessage = builder.debugMessage;
+        this.subErrors = builder.subErrors;
+    }
+
+    public static class Builder {
+        private HttpStatus status;
+        private LocalDateTime timestamp;
+        private String message;
+        private String debugMessage;
+        private List<ApiSubError> subErrors;
+
+        public Builder() {
+            this.subErrors = new ArrayList<>();
+        }
+
+        public Builder status(HttpStatus status) {
+            this.status = status;
+            return this;
+        }
+
+        public Builder timestamp(LocalDateTime timestamp) {
+            this.timestamp = timestamp;
+            return this;
+        }
+
+        public Builder message(String message) {
+            this.message = message;
+            return this;
+        }
+
+        public Builder debugMessage(String debugMessage) {
+            this.debugMessage = debugMessage;
+            return this;
+        }
+
+        public Builder addAllSubErrors(List<ApiSubError> subErrors) {
+            if (subErrors != null) {
+                this.subErrors.addAll(subErrors);
+            }
+            return this;
+        }
+
+        public Builder addSubError(ApiSubError subError) {
+            this.subErrors.add(subError);
+            return this;
+        }
+
+        public ApiError build() {
+            Objects.requireNonNull(this.timestamp);
+            Objects.requireNonNull(this.message);
+            Objects.requireNonNull(this.status);
+            return new ApiError(this);
+        }
+    }
+
+    public HttpStatus getStatus() {
+        return status;
+    }
+
+    public LocalDateTime getTimestamp() {
+        return timestamp;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public String getDebugMessage() {
+        return debugMessage;
+    }
+
+    public List<ApiSubError> getSubErrors() {
+        return subErrors;
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/type/ApiSubError.java
+++ b/src/main/java/edu/hawaii/its/api/type/ApiSubError.java
@@ -1,0 +1,17 @@
+package edu.hawaii.its.api.type;
+
+public abstract class ApiSubError {
+    private String message;
+
+    protected ApiSubError(String message) {
+        this.message = message;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/type/ApiValidationError.java
+++ b/src/main/java/edu/hawaii/its/api/type/ApiValidationError.java
@@ -1,0 +1,44 @@
+package edu.hawaii.its.api.type;
+
+public class ApiValidationError extends ApiSubError {
+    private String object;
+    private String field;
+    private Object rejectedValue;
+
+    public ApiValidationError(String object, String message) {
+        super(message);
+        this.object = object;
+    }
+
+    public ApiValidationError(String object, String field, Object rejectedValue, String message) {
+        super(message);
+        this.object = object;
+        this.field = field;
+        this.rejectedValue = rejectedValue;
+    }
+
+    public String getObject() {
+        return object;
+    }
+
+    public void setObject(String object) {
+        this.object = object;
+    }
+
+    public String getField() {
+        return field;
+    }
+
+    public void setField(String field) {
+        this.field = field;
+    }
+
+    public Object getRejectedValue() {
+        return rejectedValue;
+    }
+
+    public void setRejectedValue(Object rejectedValue) {
+        this.rejectedValue = rejectedValue;
+    }
+
+}

--- a/src/test/java/edu/hawaii/its/api/controller/ErrorControllerAdviceTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/ErrorControllerAdviceTest.java
@@ -1,11 +1,34 @@
 package edu.hawaii.its.api.controller;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
 
+import edu.hawaii.its.api.exception.UhMemberNotFoundException;
+import edu.hawaii.its.api.service.MembershipService;
+import edu.hawaii.its.api.service.MemberService;
+import edu.hawaii.its.api.service.AsyncJobsManager;
+import edu.hawaii.its.api.service.GroupingAttributeService;
+import edu.hawaii.its.api.service.GroupingAssignmentService;
+import edu.hawaii.its.api.service.MemberAttributeService;
+import edu.hawaii.its.api.service.UpdateMemberService;
+import edu.hawaii.its.api.service.GroupingOwnerService;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
@@ -13,12 +36,63 @@ import edu.hawaii.its.api.exception.AccessDeniedException;
 import edu.hawaii.its.api.exception.GroupingsServiceResultException;
 
 import edu.internet2.middleware.grouperClient.ws.GcWebServiceError;
+import org.springframework.web.context.WebApplicationContext;
 
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 public class ErrorControllerAdviceTest {
 
     @Autowired
     private ErrorControllerAdvice errorControllerAdvice;
+
+    @Value("${groupings.api.listserv}")
+    private String LISTSERV;
+
+    @Value("${groupings.api.releasedgrouping}")
+    private String RELEASED_GROUPING;
+
+    @Value("${groupings.api.current_user}")
+    private String CURRENT_USER;
+
+    @Value("${groupings.api.success}")
+    private String SUCCESS;
+
+    @MockBean
+    private AsyncJobsManager asyncJobsManager;
+
+    @MockBean
+    private GroupingAttributeService groupingAttributeService;
+
+    @MockBean
+    private GroupingAssignmentService groupingAssignmentService;
+
+    @MockBean
+    private MemberAttributeService memberAttributeService;
+
+    @MockBean
+    private MembershipService membershipService;
+
+    @MockBean
+    private UpdateMemberService updateMemberService;
+    @MockBean
+    private GroupingOwnerService groupingOwnerService;
+
+    @MockBean
+    private MemberService memberService;
+
+    @Autowired
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    private static final String API_BASE = "/api/groupings/v2.1";
+    private static final String GROUPING = "grouping";
+    private static final String USERNAME = "user";
+    private static final String ADMIN = "admin";
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = webAppContextSetup(context).build();
+    }
 
     /**
      * Testing for the ErrorControllerAdvice class.
@@ -57,5 +131,48 @@ public class ErrorControllerAdviceTest {
         UnsupportedOperationException uoe = new UnsupportedOperationException();
         statusCode = errorControllerAdvice.handleUnsupportedOperationException(uoe).getStatusCode().toString();
         assertThat(statusCode, is("501 NOT_IMPLEMENTED"));
+    }
+
+    @Test
+    public void testMembershipResultsExceptionHandling() throws Exception {
+        String uhIdentifier = "1234";
+
+        //when current_user and uhIdentifier is same, but uhIdentifier is not valid
+        given(membershipService.membershipResults(uhIdentifier, uhIdentifier)).willThrow(UhMemberNotFoundException.class);
+
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/{uhIdentifier}/memberships", uhIdentifier)
+                        .header(CURRENT_USER, uhIdentifier))
+                .andExpect(status().isNotFound()) // Checking for a 404 status
+                .andExpect(jsonPath("$.status").value("NOT_FOUND"))
+                .andExpect(jsonPath("$.message").value("UH Member found failed"))
+                .andExpect(jsonPath("$.debugMessage").value("This is not the validation error from frontend, check Sub Error to see the reason in the backend"))
+                .andExpect(jsonPath("$.subErrors").isArray()) // Checking if subErrors is an array
+                .andExpect(jsonPath("$.subErrors", hasSize(0))) // Checking if subErrors array is empty
+                .andReturn();
+
+        String content = result.getResponse().getContentAsString();
+        assertThat(result, notNullValue());
+        assertTrue(content.contains("NOT_FOUND"));
+    }
+    @Test
+    public void throwExceptionTest() throws Exception {
+        MvcResult result = mockMvc.perform(get(API_BASE + "/testing/exception"))
+                .andExpect(status().isInternalServerError()) // Checking for a 500 status
+                .andExpect(jsonPath("$.status").value("INTERNAL_SERVER_ERROR"))
+                .andExpect(jsonPath("$.message").value("Validation failed"))
+                .andExpect(jsonPath("$.debugMessage").value("Check your service at endpoint /exception"))
+                .andExpect(jsonPath("$.subErrors").isArray()) // Checking if subErrors is an array
+                .andExpect(jsonPath("$.subErrors", hasSize(2))) // Checking if subErrors array has 2 elements
+                .andExpect(jsonPath("$.subErrors[0].object").value("testing object 1"))
+                .andExpect(jsonPath("$.subErrors[0].field").value("membership service"))
+                .andExpect(jsonPath("$.subErrors[0].rejectedValue").value("id: 12"))
+                .andExpect(jsonPath("$.subErrors[0].message").value("Membership access denied"))
+                .andExpect(jsonPath("$.subErrors[1].object").value("testing object 2"))
+                .andExpect(jsonPath("$.subErrors[1].field").value("member service"))
+                .andExpect(jsonPath("$.subErrors[1].rejectedValue").value("id: 30"))
+                .andExpect(jsonPath("$.subErrors[1].message").value("There is no member"))
+                .andReturn();
+
+        assertThat(result, notNullValue());
     }
 }

--- a/src/test/java/edu/hawaii/its/api/controller/ForTestingRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/ForTestingRestControllerTest.java
@@ -15,7 +15,7 @@ import org.springframework.web.context.WebApplicationContext;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
 
 @SpringBootTest(classes = { SpringBootWebApplication.class })
-public class GroupingsRestControllerv2_1ForTestingTest {
+public class ForTestingRestControllerTest {
 
     private static final String API_BASE = "/api/groupings/v2.1/testing";
     @Autowired

--- a/src/test/java/edu/hawaii/its/api/type/ApiErrorTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/ApiErrorTest.java
@@ -1,0 +1,123 @@
+package edu.hawaii.its.api.type;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ApiErrorTest {
+    private ApiError.Builder errorBuilder;
+
+    @BeforeEach
+    public void setup() {
+        errorBuilder = new ApiError.Builder();
+    }
+
+    @Test
+    public void testApiErrorWithMultipleSubErrors() {
+        LocalDateTime timestamp = LocalDateTime.now();
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        String message = "Test error message";
+        String debugMessage = "Debugging error message";
+
+        // Create ApiSubError instances
+        ApiSubError subError1 = new ApiValidationError("testing object 1", "membership service", "id: 12", "Membership access denied");
+        ApiSubError subError2 = new ApiValidationError("testing object 2", "member service", "id: 30", "There is no member");
+
+        // Create a list of ApiSubError
+        List<ApiSubError> subErrors = new ArrayList<>();
+        subErrors.add(subError1);
+        subErrors.add(subError2);
+
+        errorBuilder
+                .status(status)
+                .timestamp(timestamp)
+                .message(message)
+                .debugMessage(debugMessage);
+
+        // Build ApiError by adding subErrors in a loop
+        for (ApiSubError subError : subErrors) {
+            errorBuilder.addSubError(subError);
+        }
+
+        // Build ApiError (Standard Failure Object)
+        ApiError apiError = errorBuilder.build();
+
+        assertNotNull(apiError);
+        assertEquals(status, apiError.getStatus());
+        assertEquals(timestamp, apiError.getTimestamp());
+        assertEquals(message, apiError.getMessage());
+        assertEquals(debugMessage, apiError.getDebugMessage());
+
+        // Check if the subErrors in the ApiError match the ones added
+        assertEquals(subErrors.size(), apiError.getSubErrors().size());
+        assertTrue(apiError.getSubErrors().containsAll(subErrors));
+    }
+
+    @Test
+    public void testApiErrorWithoutSubErrorsMethods() {
+        LocalDateTime timestamp = LocalDateTime.now();
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+        String message = "Test message";
+        ApiError apiError = new ApiError.Builder()
+                .status(status)
+                .timestamp(timestamp)
+                .message(message)
+                .build();
+
+        assertEquals(status, apiError.getStatus());
+        assertEquals(timestamp, apiError.getTimestamp());
+        assertEquals(message, apiError.getMessage());
+        assertNull(apiError.getDebugMessage());
+        assertTrue(apiError.getSubErrors().isEmpty());
+    }
+
+    @Test
+    public void testApiErrorBuilderRequiredFields() {
+        // Attempting to build without required fields should throw NullPointerException
+        assertThrows(NullPointerException.class, () -> errorBuilder.build());
+    }
+
+    @Test
+    public void testApiErrorWithoutRequiredFields() {
+
+        // Try building ApiError without timestamp
+        assertThrows(NullPointerException.class, () -> {
+            errorBuilder
+                    .status(HttpStatus.BAD_REQUEST)
+                    .message("Test error message")
+                    .debugMessage("Debugging error message")
+                    .build();
+        });
+
+        // Try building ApiError without message
+        assertThrows(NullPointerException.class, () -> {
+            errorBuilder = new ApiError.Builder();
+            errorBuilder
+                    .status(HttpStatus.BAD_REQUEST)
+                    .timestamp(LocalDateTime.now())
+                    .debugMessage("Debugging error message")
+                    .build();
+        });
+
+        // Try building ApiError without status
+        assertThrows(NullPointerException.class, () -> {
+            errorBuilder = new ApiError.Builder();
+            errorBuilder
+                    .timestamp(LocalDateTime.now())
+                    .message("Test error message")
+                    .debugMessage("Debugging error message")
+                    .build();
+        });
+    }
+
+}

--- a/src/test/java/edu/hawaii/its/api/type/ApiValidationErrorTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/ApiValidationErrorTest.java
@@ -1,0 +1,74 @@
+package edu.hawaii.its.api.type;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ApiValidationErrorTest {
+    private ApiValidationError validationError;
+
+    @BeforeEach
+    public void setup() {
+        validationError = new ApiValidationError("TestObject", "TestField", "RejectedValue", "Test message");
+    }
+
+    @Test
+    public void testConstructorAndGetter() {
+        assertEquals("TestObject", validationError.getObject());
+        assertEquals("TestField", validationError.getField());
+        assertEquals("RejectedValue", validationError.getRejectedValue());
+        assertEquals("Test message", validationError.getMessage());
+    }
+
+    @Test
+    public void testSetters() {
+        validationError.setObject("NewObject");
+        validationError.setField("NewField");
+        validationError.setRejectedValue("NewRejectedValue");
+        validationError.setMessage("New message");
+
+        assertEquals("NewObject", validationError.getObject());
+        assertEquals("NewField", validationError.getField());
+        assertEquals("NewRejectedValue", validationError.getRejectedValue());
+        assertEquals("New message", validationError.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithLessParameters() {
+        ApiValidationError errorWithLessParams = new ApiValidationError("TestObject", "Test message");
+        assertEquals("TestObject", errorWithLessParams.getObject());
+        assertNull(errorWithLessParams.getField());
+        assertNull(errorWithLessParams.getRejectedValue());
+        assertEquals("Test message", errorWithLessParams.getMessage());
+    }
+
+    @Test
+    public void testApiValidationErrorIntegrationWithApiError() {
+        HttpStatus status = HttpStatus.BAD_REQUEST;
+        LocalDateTime timestamp = LocalDateTime.now();
+        String message = "Error message";
+
+        ApiValidationError subError1 = new ApiValidationError("Object1", "Field1", "Value1", "Invalid value for Field1");
+        ApiValidationError subError2 = new ApiValidationError("Object2", "Field2", "Value2", "Invalid value for Field2");
+
+        ApiError apiError = new ApiError.Builder()
+                .status(status)
+                .timestamp(timestamp)
+                .message(message)
+                .addAllSubErrors(Arrays.asList(subError1, subError2))
+                .build();
+
+        assertNotNull(apiError.getSubErrors());
+        assertEquals(2, apiError.getSubErrors().size());
+        assertTrue(apiError.getSubErrors().contains(subError1));
+        assertTrue(apiError.getSubErrors().contains(subError2));
+    }
+}


### PR DESCRIPTION
# Ticket Link

[Ticket 1538](https://uhawaii.atlassian.net/browse/GROUPINGS-1538)

# List of squashed commits

- Create ExceptionForTesting exception with ApiError and SubError for endpoint /exception
- Add maven library for timestamp JsonFormat (Jackson)
- Create Sub Error to contain the error data of service layer to be used in UI side
- Create ApiValidationError for the data to be set in the subError objecdt
- Create Test for RestExceptionHandler
- Create RestExceptionHandler for handling global error from dispatcher
- Change the throwable object with ApiError and SubApiError at the /exception endpoint
- Make the test for expected json from the endpoint /exception
- Modify the content of the error message for ExceptionForTesting exception
- Create the test for the type ApiError (Standard Failure Object)
- Add instance of List<ApiSubError> subErrors for contain the sub error on the error response
- Clean up the function of future ticket for refactoring the exception handling, just leave the exception for test and one of the Exception that is thrown from service layer
- Add the tests for checking the json content of the ApiError object from RestExceptionHandler at the controller and service layer.
- Add the function 'addAllSubErrors' for clean code
- Merge the functions from RestExceptionHandler to ErrorControllerAdvice
- Modify existed error handling functions in ErrorControllerAdvice
- Remove RestExeptionHandlerTest
- Fix spelling error
- Put message variable and its getters and setters into the ApiSubError abstract class
- Move all the tests from RestExceptionHanlderTest to ErrorControllerAdviceTest and remove the file of RestExceptionHanlderTest
- Modify the result of the status in regex test from ClIENT_ERROR to SERVER_ERROR
- Add comment for custom exception test section
- Remove JsonFormat library for timestamp at ApiError
- Remove maven library jackson-datatype-jsr310 for timestamp
- Add the logic for verifying whether the subErrors list passed to addAllSubErrors is empty
- Set the return type to ReponseEntity<ApiError>
- Set PropertyLocator as local variable
- Remove import for codacy
- Include assert() for JUnit test
- Remove PropertyLocator before making new integration test
- Writing a unit test for ApiValidationError
- Remove comments and * from import
- Remove * import and use single class import

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
