### PR TITLE
Implement the function to modify data harness bean with JSON data from API request

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -51,6 +51,7 @@ import edu.hawaii.its.api.service.UpdateMemberService;
 import edu.hawaii.its.api.type.Announcements;
 import edu.hawaii.its.api.type.AsyncJobResult;
 import edu.hawaii.its.api.type.GroupingsServiceResult;
+import edu.hawaii.its.api.type.OotbActiveProfile;
 import edu.hawaii.its.api.type.OotbActiveProfileResult;
 import edu.hawaii.its.api.type.OptRequest;
 import edu.hawaii.its.api.type.OptType;
@@ -682,15 +683,12 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Update Ootb active user profile.
      */
-    @PostMapping(value = "/activeProfile/ootb")
-    public ResponseEntity<OotbActiveProfileResult> updateOotbActiveUserProfile(@RequestBody List<String> authorities,
-                                                                               @RequestParam(required = true) String uid,
-                                                                               @RequestParam(required = true) String uhUuid,
-                                                                               @RequestParam(required = true) String name,
-                                                                               @RequestParam(required = true) String givenName) {
-        logger.debug("Entered REST updateActiveUserProfile...");
+     @PostMapping(value = "/activeProfile/ootb")
+     public ResponseEntity<OotbActiveProfileResult> updateOotbActiveUserGroupings(@RequestBody OotbActiveProfile ootbActiveProfile) {
+        logger.debug("Entered REST updateOotbActiveUserGroupings...");
         return ResponseEntity
                 .ok()
-                .body(ootbGroupingPropertiesService.updateActiveUserProfile(authorities, uid, uhUuid, name, givenName));
-    }
+                .body(ootbGroupingPropertiesService.updateActiveUserProfile(ootbActiveProfile));
+     }
+
 }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAttributeService.java
@@ -145,7 +145,9 @@ public class GroupingAttributeService {
                 currentUser, ASSIGN_TYPE_GROUP, assignOperation, groupingPath, attributeName);
 
         GroupingUpdatedAttributesResult result = new GroupingUpdatedAttributesResult(assignAttributesResults);
-        timestampService.update(result);
+        if(grouperService instanceof GrouperApiService) {
+            timestampService.update(result);
+        }
         return result;
     }
 

--- a/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
@@ -1,5 +1,6 @@
 package edu.hawaii.its.api.service;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.logging.Log;
@@ -21,7 +22,9 @@ import edu.hawaii.its.api.wrapper.RemoveMemberResult;
 import edu.hawaii.its.api.wrapper.RemoveMembersResults;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
 
+import edu.internet2.middleware.grouperClient.ws.beans.WsAssignGrouperPrivilegesLiteResult;
 import edu.internet2.middleware.grouperClient.ws.beans.WsFindAttributeDefNamesResults;
+import edu.internet2.middleware.grouperClient.ws.beans.WsResultMeta;
 
 public class OotbGrouperApiService implements GrouperService {
 
@@ -32,6 +35,7 @@ public class OotbGrouperApiService implements GrouperService {
     public OotbGrouperApiService(OotbGroupingPropertiesService ootbGroupingPropertiesService) {
         this.ootbGroupingPropertiesService = ootbGroupingPropertiesService;
     }
+
     /**
      * Check if a UH identifier is listed in a group.
      */
@@ -105,7 +109,8 @@ public class OotbGrouperApiService implements GrouperService {
      * Check if a group contains an attribute.
      */
     public GroupAttributeResults groupAttributeResults(String attribute, String groupPath) {
-        return ootbGroupingPropertiesService.getGroupAttributeResults();
+        return ootbGroupingPropertiesService.getGroupAttributeResultsByAttributeAndGroupPathList(attribute,
+                Collections.singletonList(groupPath));
     }
 
     /**
@@ -141,7 +146,7 @@ public class OotbGrouperApiService implements GrouperService {
     }
 
     public GroupAttributeResults groupAttributeResult(String currentUser, String groupPath) {
-        return ootbGroupingPropertiesService.getGroupAttributeResults();
+        return ootbGroupingPropertiesService.getGroupAttributeResults(currentUser, groupPath);
     }
 
     /**
@@ -235,7 +240,7 @@ public class OotbGrouperApiService implements GrouperService {
     public AssignAttributesResults assignAttributesResults(String currentUser, String assignType,
             String assignOperation, String groupPath,
             String attributeName) {
-        return ootbGroupingPropertiesService.getAssignAttributesResults();
+        return ootbGroupingPropertiesService.manageAttributeAssignment(groupPath, attributeName, assignOperation);
     }
 
     /**
@@ -244,7 +249,14 @@ public class OotbGrouperApiService implements GrouperService {
     public AssignGrouperPrivilegesResult assignGrouperPrivilegesResult(String currentUser, String groupPath,
             String privilegeName,
             String uhIdentifier, boolean isAllowed) {
-        return new AssignGrouperPrivilegesResult();
+
+        WsAssignGrouperPrivilegesLiteResult wsAssignGrouperPrivilegesLiteResult =
+                new WsAssignGrouperPrivilegesLiteResult();
+        WsResultMeta resultMetadata = new WsResultMeta();
+        resultMetadata.setResultCode("SUCCESS");
+        wsAssignGrouperPrivilegesLiteResult.setResultMetadata(resultMetadata);
+
+        return new AssignGrouperPrivilegesResult(wsAssignGrouperPrivilegesLiteResult);
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/PathFilter.java
+++ b/src/main/java/edu/hawaii/its/api/service/PathFilter.java
@@ -87,4 +87,12 @@ public class PathFilter {
         }
         return parentPath.substring(parentPath.lastIndexOf(":") + 1, parentPath.length());
     }
+
+    public static String extractExtension(String groupPath) {
+        int colonIndex = groupPath.indexOf(":");
+        if (colonIndex != -1) {
+            return groupPath.substring(colonIndex + 1);
+        }
+        return "";
+    }
 }

--- a/src/main/java/edu/hawaii/its/api/type/OotbActiveProfile.java
+++ b/src/main/java/edu/hawaii/its/api/type/OotbActiveProfile.java
@@ -1,77 +1,48 @@
 package edu.hawaii.its.api.type;
 
 import java.util.List;
+import java.util.Map;
 
 public class OotbActiveProfile {
+    private String uid;
+    private String uhUuid;
+    private List<String> authorities;
+    private Map<String, String> attributes;
+    private List<OotbGrouping> ootbGroupings;
 
-    private final String uid;
-    private final String uhUuid;
-    private final String name;
-    private final String givenName;
-    private final List<String> authorities;
+    public List<OotbGrouping> getGroupings() { return ootbGroupings; }
 
-    OotbActiveProfile(Builder builder) {
-        this.uid = builder.uid;
-        this.uhUuid = builder.uhUuid;
-        this.name = builder.name;
-        this.givenName = builder.givenName;
-        this.authorities = builder.authorities;
-    }
+    public void setGroupings(List<OotbGrouping> ootbGroupings) { this.ootbGroupings = ootbGroupings; }
 
     public String getUid() {
         return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
     }
 
     public String getUhUuid() {
         return uhUuid;
     }
 
-    public String getName() {
-        return name;
-    }
-
-    public String getGivenName() {
-        return givenName;
+    public void setUhUuid(String uhUuid) {
+        this.uhUuid = uhUuid;
     }
 
     public List<String> getAuthorities() {
         return authorities;
     }
 
-    public static class Builder {
-        private String uid;
-        private String uhUuid;
-        private String name;
-        private String givenName;
-        private List<String> authorities;
+    public void setAuthorities(List<String> authorities) {
+        this.authorities = authorities;
+    }
 
-        public Builder uid(String uid) {
-            this.uid = uid;
-            return this;
-        }
+    public Map<String, String> getAttributes() {
+        return attributes;
+    }
 
-        public Builder uhUuid(String uhUuid) {
-            this.uhUuid = uhUuid;
-            return this;
-        }
-
-        public Builder name(String name) {
-            this.name = name;
-            return this;
-        }
-
-        public Builder givenName(String givenName) {
-            this.givenName = givenName;
-            return this;
-        }
-
-        public Builder authorities(List<String> authorities) {
-            this.authorities = authorities;
-            return this;
-        }
-
-        public OotbActiveProfile build() {
-            return new OotbActiveProfile(this);
-        }
+    public void setAttributes(Map<String, String> attributes) {
+        this.attributes = attributes;
     }
 }

--- a/src/main/java/edu/hawaii/its/api/type/OotbActiveProfileResult.java
+++ b/src/main/java/edu/hawaii/its/api/type/OotbActiveProfileResult.java
@@ -11,7 +11,7 @@ public class OotbActiveProfileResult {
 
     public OotbActiveProfileResult() {
         setResultCode("FAILURE");
-        setResult(new OotbActiveProfile.Builder().build());
+        setResult(null);
     }
 
     public String getResultCode() {

--- a/src/main/java/edu/hawaii/its/api/type/OotbGrouping.java
+++ b/src/main/java/edu/hawaii/its/api/type/OotbGrouping.java
@@ -1,0 +1,71 @@
+package edu.hawaii.its.api.type;
+
+import java.util.List;
+
+public class OotbGrouping {
+    private String name;
+    private String displayName;
+    private String extension;
+    private String displayExtension;
+    private String description;
+    private List<OotbMember> members;
+
+    public OotbGrouping(String name, String displayName, String extension, String displayExtension, String description,
+            List<OotbMember> members) {
+        this.name = name;
+        this.displayName = displayName;
+        this.extension = extension;
+        this.displayExtension = displayExtension;
+        this.description = description;
+        this.members = members;
+    }
+    public OotbGrouping() {}
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDisplayName() {
+        return displayName;
+    }
+
+    public void setDisplayName(String displayName) {
+        this.displayName = displayName;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public void setExtension(String extension) {
+        this.extension = extension;
+    }
+
+    public String getDisplayExtension() {
+        return displayExtension;
+    }
+
+    public void setDisplayExtension(String displayExtension) {
+        this.displayExtension = displayExtension;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public List<OotbMember> getMembers() {
+        return members;
+    }
+
+    public void setMembers(List<OotbMember> members) {
+        this.members = members;
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/type/OotbMember.java
+++ b/src/main/java/edu/hawaii/its/api/type/OotbMember.java
@@ -1,0 +1,40 @@
+package edu.hawaii.its.api.type;
+
+public class OotbMember {
+
+    private String name;
+    private String uhUuid;
+    private String uid;
+
+    public OotbMember(String name, String uhUuid, String uid) {
+        this.name = name;
+        this.uhUuid = uhUuid;
+        this.uid = uid;
+    }
+
+    public OotbMember() {}
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getUhUuid() {
+        return uhUuid;
+    }
+
+    public void setUhUuid(String uhUuid) {
+        this.uhUuid = uhUuid;
+    }
+
+    public String getUid() {
+        return uid;
+    }
+
+    public void setUid(String uid) {
+        this.uid = uid;
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/configuration/OotbGrouperPropertyConfigurerTest.java
+++ b/src/test/java/edu/hawaii/its/api/configuration/OotbGrouperPropertyConfigurerTest.java
@@ -1,6 +1,7 @@
 package edu.hawaii.its.api.configuration;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,8 +9,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.ApplicationContext;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 
+import edu.hawaii.its.api.service.GrouperService;
+import edu.hawaii.its.api.service.OotbGrouperApiService;
 import edu.hawaii.its.api.service.OotbGroupingPropertiesService;
 import edu.hawaii.its.api.wrapper.AddMembersResults;
 import edu.hawaii.its.api.wrapper.AssignAttributesResults;
@@ -23,7 +28,7 @@ import edu.hawaii.its.api.wrapper.HasMembersResults;
 import edu.hawaii.its.api.wrapper.RemoveMembersResults;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
 
-@SpringBootTest(classes = {SpringBootWebApplication.class})
+@SpringBootTest(classes = { SpringBootWebApplication.class })
 @ActiveProfiles("ootb")
 @TestPropertySource(locations = "classpath:ootb.grouper.test.properties")
 public class OotbGrouperPropertyConfigurerTest {
@@ -33,6 +38,11 @@ public class OotbGrouperPropertyConfigurerTest {
 
     @MockBean
     private OotbGroupingPropertiesService ootbGroupingPropertiesService;
+
+    @DynamicPropertySource
+    static void grouperProperties(DynamicPropertyRegistry registry) {
+        registry.add("grouping.api.server.type", () -> "OOTB");
+    }
 
     @Test
     public void testHasMembersResultsOOTBBean() {
@@ -111,7 +121,8 @@ public class OotbGrouperPropertyConfigurerTest {
 
     @Test
     public void testAssignGrouperPrivilegesResultOOTBBean() {
-        AssignGrouperPrivilegesResult bean = context.getBean("AssignGrouperPrivilegesResultOOTBBean", AssignGrouperPrivilegesResult.class);
+        AssignGrouperPrivilegesResult bean =
+                context.getBean("AssignGrouperPrivilegesResultOOTBBean", AssignGrouperPrivilegesResult.class);
         assertNotNull(bean);
         assertNotNull(bean.getGroup());
         assertNotNull(bean.getResultCode());
@@ -119,6 +130,7 @@ public class OotbGrouperPropertyConfigurerTest {
         assertNotNull(bean.getSubject());
         assertNotNull(bean.isAllowed());
     }
+
     @Test
     public void testGetGroupsResultsOOTBBean() {
         GetGroupsResults bean = context.getBean("GetGroupsResultsOOTBBean", GetGroupsResults.class);
@@ -128,4 +140,10 @@ public class OotbGrouperPropertyConfigurerTest {
         assertNotNull(bean.getSubject());
     }
 
+    @Test
+    public void testGrouperApiOOTBService() {
+        GrouperService service = context.getBean("grouperService", GrouperService.class);
+        assertNotNull(service);
+        assertTrue(service instanceof OotbGrouperApiService);
+    }
 }

--- a/src/test/java/edu/hawaii/its/api/service/OotbGrouperApiServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/OotbGrouperApiServiceTest.java
@@ -1,6 +1,5 @@
 package edu.hawaii.its.api.service;
 
-import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -33,15 +32,14 @@ import edu.hawaii.its.api.wrapper.SubjectsResults;
 public class OotbGrouperApiServiceTest {
 
     @Autowired
-    GrouperService grouperService;
+    OotbGrouperApiService ootbGrouperService;
 
     @MockBean
     private OotbGroupingPropertiesService ootbGroupingPropertiesService;
 
     @Test
     public void isGrouperApiOOTBService() {
-        assertThat(grouperService, notNullValue());
-        assertThat(grouperService instanceof OotbGrouperApiService, equalTo(true));
+        assertThat(ootbGrouperService, notNullValue());
     }
 
     @Test
@@ -52,7 +50,7 @@ public class OotbGrouperApiServiceTest {
         when(ootbGroupingPropertiesService.getGroups(uhIdentifier)).thenReturn(expectedResults);
 
         // Act
-        GetGroupsResults actualResults = grouperService.getGroupsResults(uhIdentifier);
+        GetGroupsResults actualResults = ootbGrouperService.getGroupsResults(uhIdentifier);
 
         // Assert
         assertEquals(expectedResults, actualResults);
@@ -72,7 +70,7 @@ public class OotbGrouperApiServiceTest {
 
         // Execution
         GetMembersResults actual =
-                grouperService.getMembersResults(groupPaths);
+                ootbGrouperService.getMembersResults(groupPaths);
 
         // Verification
         assertEquals(expected, actual);
@@ -87,7 +85,7 @@ public class OotbGrouperApiServiceTest {
         when(ootbGroupingPropertiesService.getFindGroups(groupPath)).thenReturn(expectedResults);
 
         // Act
-        FindGroupsResults actualResults = grouperService.findGroupsResults(groupPath);
+        FindGroupsResults actualResults = ootbGrouperService.findGroupsResults(groupPath);
 
         // Assert
         assertEquals(expectedResults, actualResults);
@@ -102,7 +100,7 @@ public class OotbGrouperApiServiceTest {
         when(ootbGroupingPropertiesService.updateDescription(groupingPath, description)).thenReturn(expected);
 
         // Act
-        GroupSaveResults result = grouperService.groupSaveResults(groupingPath, description);
+        GroupSaveResults result = ootbGrouperService.groupSaveResults(groupingPath, description);
 
         // Assert
         assertEquals(expected, result);
@@ -114,20 +112,21 @@ public class OotbGrouperApiServiceTest {
         // Setup
         String currentUser = "testiwta";
         String assignType = "group";
-        String assignOperation = "opt-in";
+        String assignOperation = "assign_attr";
         String groupPath = "group-0-1";
-        String attributeName = "attribute1";
+        String attributeName = "uh-settings:attributes:for-groups:uh-grouping:anyone-can:opt-in";
         AssignAttributesResults expected = new AssignAttributesResults();
-        when(ootbGroupingPropertiesService.getAssignAttributesResults()).thenReturn(expected);
+        when(ootbGroupingPropertiesService.manageAttributeAssignment(groupPath, attributeName,
+                assignOperation)).thenReturn(expected);
 
         // Execution
         AssignAttributesResults actual =
-                grouperService.assignAttributesResults(currentUser, assignType, assignOperation, groupPath,
+                ootbGrouperService.assignAttributesResults(currentUser, assignType, assignOperation, groupPath,
                         attributeName);
 
         // Verification
         assertEquals(expected, actual);
-        verify(ootbGroupingPropertiesService).getAssignAttributesResults();
+        verify(ootbGroupingPropertiesService).manageAttributeAssignment(groupPath, attributeName, assignOperation);
     }
 
     // Test for validating UH identifier
@@ -135,11 +134,11 @@ public class OotbGrouperApiServiceTest {
     public void testGetSubjectsSingle() {
         // Setup
         String uhIdentifier = "12345";
-        SubjectsResults expectedResults = new SubjectsResults(); // Properly initialized or mocked
+        SubjectsResults expectedResults = new SubjectsResults();
         when(ootbGroupingPropertiesService.getSubject(uhIdentifier)).thenReturn(expectedResults);
 
         // Execution
-        SubjectsResults result = grouperService.getSubjects(uhIdentifier);
+        SubjectsResults result = ootbGrouperService.getSubjects(uhIdentifier);
 
         // Verification
         verify(ootbGroupingPropertiesService).getSubject(uhIdentifier);
@@ -150,11 +149,11 @@ public class OotbGrouperApiServiceTest {
     public void testGetSubjectsMultiple() {
         // Setup
         List<String> uhIdentifiers = List.of("12345", "67890");
-        SubjectsResults expectedResults = new SubjectsResults(); // Mock or use a real instance
+        SubjectsResults expectedResults = new SubjectsResults();
         when(ootbGroupingPropertiesService.getSubjects(uhIdentifiers)).thenReturn(expectedResults);
 
         // Execution
-        SubjectsResults result = grouperService.getSubjects(uhIdentifiers);
+        SubjectsResults result = ootbGrouperService.getSubjects(uhIdentifiers);
 
         // Verification
         verify(ootbGroupingPropertiesService).getSubjects(uhIdentifiers);
@@ -167,11 +166,11 @@ public class OotbGrouperApiServiceTest {
         String currentUser = "testUser";
         String groupPath = "testGroup";
         String uhIdentifier = "12345";
-        AddMemberResult expected = new AddMemberResult(); // Assume this is properly initialized
+        AddMemberResult expected = new AddMemberResult();
         when(ootbGroupingPropertiesService.addMember(currentUser, groupPath, uhIdentifier)).thenReturn(expected);
 
         // Execution
-        AddMemberResult result = grouperService.addMember(currentUser, groupPath, uhIdentifier);
+        AddMemberResult result = ootbGrouperService.addMember(currentUser, groupPath, uhIdentifier);
 
         // Verification
         verify(ootbGroupingPropertiesService).addMember(currentUser, groupPath, uhIdentifier);
@@ -184,11 +183,11 @@ public class OotbGrouperApiServiceTest {
         String currentUser = "testUser";
         String groupPath = "testGroup";
         List<String> uhIdentifiers = List.of("12345", "67890");
-        AddMembersResults expected = new AddMembersResults(); // Assume this is properly initialized
+        AddMembersResults expected = new AddMembersResults();
         when(ootbGroupingPropertiesService.addMembers(currentUser, groupPath, uhIdentifiers)).thenReturn(expected);
 
         // Execution
-        AddMembersResults result = grouperService.addMembers(currentUser, groupPath, uhIdentifiers);
+        AddMembersResults result = ootbGrouperService.addMembers(currentUser, groupPath, uhIdentifiers);
 
         // Verification
         verify(ootbGroupingPropertiesService).addMembers(currentUser, groupPath, uhIdentifiers);
@@ -201,11 +200,11 @@ public class OotbGrouperApiServiceTest {
         String currentUser = "testUser";
         String groupPath = "testGroup";
         String uhIdentifier = "12345";
-        RemoveMemberResult expected = new RemoveMemberResult(); // Assume properly initialized
+        RemoveMemberResult expected = new RemoveMemberResult();
         when(ootbGroupingPropertiesService.removeMember(currentUser, groupPath, uhIdentifier)).thenReturn(expected);
 
         // Execution
-        RemoveMemberResult result = grouperService.removeMember(currentUser, groupPath, uhIdentifier);
+        RemoveMemberResult result = ootbGrouperService.removeMember(currentUser, groupPath, uhIdentifier);
 
         // Verification
         verify(ootbGroupingPropertiesService).removeMember(currentUser, groupPath, uhIdentifier);
@@ -218,11 +217,11 @@ public class OotbGrouperApiServiceTest {
         String currentUser = "testUser";
         String groupPath = "testGroup";
         List<String> uhIdentifiers = List.of("12345", "67890");
-        RemoveMembersResults expected = new RemoveMembersResults(); // Assume properly initialized
+        RemoveMembersResults expected = new RemoveMembersResults();
         when(ootbGroupingPropertiesService.removeMembers(currentUser, groupPath, uhIdentifiers)).thenReturn(expected);
 
         // Execution
-        RemoveMembersResults result = grouperService.removeMembers(currentUser, groupPath, uhIdentifiers);
+        RemoveMembersResults result = ootbGrouperService.removeMembers(currentUser, groupPath, uhIdentifiers);
 
         // Verification
         verify(ootbGroupingPropertiesService).removeMembers(currentUser, groupPath, uhIdentifiers);
@@ -233,18 +232,17 @@ public class OotbGrouperApiServiceTest {
     public void testResetGroup() {
         // Set up
         String groupPath = "groupPath-0-1";
-        AddMembersResults mockAddMembersResults = new AddMembersResults(); // Assume this is a valid class
+        AddMembersResults mockAddMembersResults = new AddMembersResults();
 
         when(ootbGroupingPropertiesService.getAddMembersResults()).thenReturn(mockAddMembersResults);
         when(ootbGroupingPropertiesService.resetGroup(groupPath)).thenReturn(mockAddMembersResults);
 
         // Execution
-        AddMembersResults results = grouperService.resetGroupMembers(groupPath);
+        AddMembersResults results = ootbGrouperService.resetGroupMembers(groupPath);
 
         // Verifications
         assertNotNull(results);
         verify(ootbGroupingPropertiesService).resetGroup(groupPath);
     }
-
 
 }

--- a/src/test/java/edu/hawaii/its/api/service/OotbGroupingPropertiesServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/OotbGroupingPropertiesServiceTest.java
@@ -2,7 +2,13 @@ package edu.hawaii.its.api.service;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -11,6 +17,7 @@ import edu.hawaii.its.api.wrapper.AddMembersResults;
 import edu.hawaii.its.api.wrapper.AssignAttributesResults;
 import edu.hawaii.its.api.wrapper.FindGroupsResults;
 import edu.hawaii.its.api.wrapper.GetGroupsResults;
+import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.GetMembersResults;
 import edu.hawaii.its.api.wrapper.GroupAttributeResults;
 import edu.hawaii.its.api.wrapper.GroupSaveResults;
@@ -18,11 +25,20 @@ import edu.hawaii.its.api.wrapper.HasMembersResults;
 import edu.hawaii.its.api.wrapper.RemoveMembersResults;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
 
+import edu.internet2.middleware.grouperClient.ws.beans.WsGetMembersResult;
+import edu.internet2.middleware.grouperClient.ws.beans.WsGroup;
+import edu.internet2.middleware.grouperClient.ws.beans.WsSubject;
+
 @SpringBootTest(classes = { SpringBootWebApplication.class })
 class OotbGroupingPropertiesServiceTest {
 
     @Autowired
     private OotbGroupingPropertiesService ootbGroupingPropertiesService;
+
+    @BeforeEach
+    public void setUp() {
+        MockitoAnnotations.openMocks(this);
+    }
 
     @Test
     public void testHasMembersResultsBean() {
@@ -83,4 +99,153 @@ class OotbGroupingPropertiesServiceTest {
         GetGroupsResults result = ootbGroupingPropertiesService.getGroupsResults();
         assertNotNull(result);
     }
+
+    @Test
+    public void testAddMembers() {
+        AddMembersResults result = ootbGroupingPropertiesService.addMembers("CURRENT_USER", "groupPath", Arrays.asList("uh1234", "admin1234"));
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testRemoveMembers() {
+        RemoveMembersResults result = ootbGroupingPropertiesService.removeMembers("CURRENT_USER", "groupPath", Arrays.asList("uh1234", "admin1234"));
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetSubject() {
+        SubjectsResults result = ootbGroupingPropertiesService.getSubject("userId");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetSubjects() {
+        SubjectsResults result = ootbGroupingPropertiesService.getSubjects(Arrays.asList("user1", "user2"));
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testResetGroup() {
+        AddMembersResults result = ootbGroupingPropertiesService.resetGroup("groupPath");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetOwnedGroupings() {
+        GetMembersResults result =
+                ootbGroupingPropertiesService.getOwnedGroupings(Arrays.asList("groupPath1", "groupPath2"));
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetGroupAttributeResultsByAttribute() {
+        GroupAttributeResults result =
+                ootbGroupingPropertiesService.getGroupAttributeResultsByAttribute("is-trio");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetGroupAttributeResultsByAttributeAndGroupPathList() {
+        GroupAttributeResults result =
+                ootbGroupingPropertiesService.getGroupAttributeResultsByAttributeAndGroupPathList("is-trio",
+                        Arrays.asList("groupPath1", "groupPath2"));
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetGroupAttributeResultsQuery() {
+        GroupAttributeResults result =
+                ootbGroupingPropertiesService.getGroupAttributeResults("currentUser", "groupPath");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetGroups() {
+        GetGroupsResults result = ootbGroupingPropertiesService.getGroups("userId");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testGetFindGroups() {
+        FindGroupsResults result = ootbGroupingPropertiesService.getFindGroups("groupPath");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testUpdateDescription() {
+        GroupSaveResults result = ootbGroupingPropertiesService.updateDescription("groupPath", "New Description");
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testManageAttributeAssignmentAssign() {
+        String groupPath = "testGroup";
+        String attributeName = "uh-settings:attributes:for-groups:uh-grouping:anyone-can:opt-in";
+        String assignOperation = "assign_attr";
+
+        AssignAttributesResults result =
+                ootbGroupingPropertiesService.manageAttributeAssignment(groupPath, attributeName, assignOperation);
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testManageAttributeAssignmentRemove() {
+        String groupPath = "testGroup";
+        String attributeName = "uh-settings:attributes:for-groups:uh-grouping:anyone-can:opt-in";
+        String assignOperation = "remove_attr";
+
+        AssignAttributesResults result =
+                ootbGroupingPropertiesService.manageAttributeAssignment(groupPath, attributeName, assignOperation);
+        assertNotNull(result);
+    }
+
+    @Test
+    public void testWsGetMembersResultsList() {
+        WsGetMembersResult[] results = ootbGroupingPropertiesService.wsGetMembersResultsList();
+        assertNotNull(results);
+    }
+
+    @Test
+    public void testGetMembersByGroupPath() {
+        GetMembersResult result = ootbGroupingPropertiesService.getMembersByGroupPath("someGroupPath");
+        Assertions.assertNull(result);
+    }
+
+    @Test
+    public void testGetWsSubjectListOfOotbUsers() {
+        WsSubject[] subjects = ootbGroupingPropertiesService.getWsSubjectListOfOotbUsers();
+        assertNotNull(subjects);
+    }
+
+    @Test
+    public void testGetWsOotbSubject() {
+        WsSubject subject = ootbGroupingPropertiesService.getWsOotbSubject("no identifier");
+        Assertions.assertNull(subject);
+    }
+
+    @Test
+    public void testGetWsOotbSubjects() {
+        List<WsSubject> subjects = ootbGroupingPropertiesService.getWsOotbSubjects(Arrays.asList("id1", "id2"));
+        assertNotNull(subjects);
+    }
+
+    @Test
+    public void testIsValidOotbUhIdentifierSingle() {
+        Boolean isValid = ootbGroupingPropertiesService.isValidOotbUhIdentifier("someIdentifier");
+        assertNotNull(isValid);
+    }
+
+    @Test
+    public void testIsValidOotbUhIdentifierList() {
+        Boolean isValid = ootbGroupingPropertiesService.isValidOotbUhIdentifier(Arrays.asList("id1", "id2"));
+        assertNotNull(isValid);
+    }
+
+    @Test
+    public void testGetWsGroupFromFindGroupsResults() {
+        FindGroupsResults findGroupsResults = new FindGroupsResults();
+        WsGroup wsGroup = ootbGroupingPropertiesService.getWsGroupFromFindGroupsResults(findGroupsResults, "somePath");
+        Assertions.assertNull(wsGroup);
+    }
+
 }

--- a/src/test/java/edu/hawaii/its/api/service/PathFilterTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/PathFilterTest.java
@@ -169,10 +169,23 @@ public class PathFilterTest {
         assertEquals("", nameGroupingPath(""));
     }
 
+    @Test
+    public void testExtractExtension() {
+        assertEquals("include", PathFilter.extractExtension("bogus:include"));
+        assertEquals("exclude", PathFilter.extractExtension("bogus:exclude"));
+        assertEquals("owners", PathFilter.extractExtension("bogus:owners"));
+        assertEquals("basis", PathFilter.extractExtension("bogus:basis"));
+        assertEquals("grouping-path", PathFilter.extractExtension("bogus:grouping-path"));
+        assertEquals("", PathFilter.extractExtension("bogus"));
+        assertEquals("", PathFilter.extractExtension(""));
+    }
+
     /**
      * General filter to filter paths with the predicates in the PathFilter class.
      */
     private static List<String> filterPaths(List<String> groupPaths, Predicate<String> predicate) {
         return groupPaths.stream().filter(predicate).collect(Collectors.toList());
     }
+
+
 }

--- a/src/test/java/edu/hawaii/its/api/type/OotbActiveProfileResultTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/OotbActiveProfileResultTest.java
@@ -1,0 +1,56 @@
+package edu.hawaii.its.api.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OotbActiveProfileResultTest {
+
+    private OotbActiveProfile ootbActiveProfile;
+
+    @BeforeEach
+    public void setUp() {
+        ootbActiveProfile = new OotbActiveProfile();
+        ootbActiveProfile.setUid("admin0123");
+        ootbActiveProfile.setUhUuid("33333333");
+    }
+
+    @Test
+    public void constructionWithProfile() {
+        OotbActiveProfileResult result = new OotbActiveProfileResult(ootbActiveProfile);
+        assertNotNull(result);
+        assertThat(result.getResultCode(), is("SUCCESS"));
+        assertNotNull(result.getResult());
+        assertThat(result.getResult().getUid(), is("admin0123"));
+        assertThat(result.getResult().getUhUuid(), is("33333333"));
+    }
+
+    @Test
+    public void constructionWithoutProfile() {
+        OotbActiveProfileResult result = new OotbActiveProfileResult();
+        assertNotNull(result);
+        assertThat(result.getResultCode(), is("FAILURE"));
+        assertNull(result.getResult());
+    }
+
+    @Test
+    public void resultCode() {
+        OotbActiveProfileResult result = new OotbActiveProfileResult();
+        result.setResultCode("CUSTOM_CODE");
+        assertThat(result.getResultCode(), is("CUSTOM_CODE"));
+    }
+
+    @Test
+    public void result() {
+        OotbActiveProfileResult result = new OotbActiveProfileResult();
+        assertNull(result.getResult());
+        result.setResult(ootbActiveProfile);
+        assertNotNull(result.getResult());
+        assertThat(result.getResult().getUid(), is("admin0123"));
+        assertThat(result.getResult().getUhUuid(), is("33333333"));
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/type/OotbActiveProfileTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/OotbActiveProfileTest.java
@@ -1,0 +1,69 @@
+package edu.hawaii.its.api.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OotbActiveProfileTest {
+
+    private OotbActiveProfile profile;
+
+    @BeforeEach
+    public void setUp() {
+        profile = new OotbActiveProfile();
+    }
+
+    @Test
+    public void construction() {
+        assertNotNull(profile);
+    }
+
+    @Test
+    public void uid() {
+        assertNull(profile.getUid());
+        profile.setUid("123456");
+        assertThat(profile.getUid(), is("123456"));
+    }
+
+    @Test
+    public void uhUuid() {
+        assertNull(profile.getUhUuid());
+        profile.setUhUuid("ABCDEF");
+        assertThat(profile.getUhUuid(), is("ABCDEF"));
+    }
+
+    @Test
+    public void authorities() {
+        assertNull(profile.getAuthorities());
+        List<String> authorities = new ArrayList<>();
+        authorities.add("ADMIN");
+        authorities.add("USER");
+        profile.setAuthorities(authorities);
+        assertNotNull(profile.getAuthorities());
+        assertThat(profile.getAuthorities().size(), is(2));
+        assertThat(profile.getAuthorities().get(0), is("ADMIN"));
+        assertThat(profile.getAuthorities().get(1), is("USER"));
+    }
+
+    @Test
+    public void attributes() {
+        assertNull(profile.getAttributes());
+        Map<String, String> attributes = new HashMap<>();
+        attributes.put("key1", "value1");
+        attributes.put("key2", "value2");
+        profile.setAttributes(attributes);
+        assertNotNull(profile.getAttributes());
+        assertThat(profile.getAttributes().size(), is(2));
+        assertThat(profile.getAttributes().get("key1"), is("value1"));
+        assertThat(profile.getAttributes().get("key2"), is("value2"));
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/type/OotbGroupingTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/OotbGroupingTest.java
@@ -1,0 +1,75 @@
+package edu.hawaii.its.api.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OotbGroupingTest {
+
+    private OotbGrouping grouping;
+
+    @BeforeEach
+    public void setUp() {
+        grouping = new OotbGrouping();
+    }
+
+    @Test
+    public void construction() {
+        assertNotNull(grouping);
+    }
+
+    @Test
+    public void name() {
+        assertNull(grouping.getName());
+        grouping.setName("group1");
+        assertThat(grouping.getName(), is("group1"));
+    }
+
+    @Test
+    public void displayName() {
+        assertNull(grouping.getDisplayName());
+        grouping.setDisplayName("group1");
+        assertThat(grouping.getDisplayName(), is("group1"));
+    }
+
+    @Test
+    public void extension() {
+        assertNull(grouping.getExtension());
+        grouping.setExtension("include");
+        assertThat(grouping.getExtension(), is("include"));
+    }
+
+    @Test
+    public void displayExtension() {
+        assertNull(grouping.getDisplayExtension());
+        grouping.setDisplayExtension("include");
+        assertThat(grouping.getDisplayExtension(), is("include"));
+    }
+
+    @Test
+    public void description() {
+        assertNull(grouping.getDescription());
+        grouping.setDescription("Description 1");
+        assertThat(grouping.getDescription(), is("Description 1"));
+    }
+
+    @Test
+    public void members() {
+        assertNull(grouping.getMembers());
+        OotbMember member1 = new OotbMember("Member One", "11111111", "member1");
+        OotbMember member2 = new OotbMember("Member Two", "22222222", "member2");
+        List<OotbMember> members = Arrays.asList(member1, member2);
+        grouping.setMembers(members);
+        assertNotNull(grouping.getMembers());
+        assertThat(grouping.getMembers().size(), is(2));
+        assertThat(grouping.getMembers().get(0).getName(), is("Member One"));
+        assertThat(grouping.getMembers().get(1).getName(), is("Member Two"));
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/type/OotbMemberTest.java
+++ b/src/test/java/edu/hawaii/its/api/type/OotbMemberTest.java
@@ -1,0 +1,61 @@
+package edu.hawaii.its.api.type;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+public class OotbMemberTest {
+
+    private OotbMember member;
+
+    @BeforeEach
+    public void setUp() {
+        member = new OotbMember();
+    }
+
+    @Test
+    public void construction() {
+        assertNotNull(member);
+    }
+
+    @Test
+    public void name() {
+        assertNull(member.getName());
+        member.setName("John Doe");
+        assertThat(member.getName(), is("John Doe"));
+    }
+
+    @Test
+    public void uhUuid() {
+        assertNull(member.getUhUuid());
+        member.setUhUuid("12345678");
+        assertThat(member.getUhUuid(), is("12345678"));
+    }
+
+    @Test
+    public void uid() {
+        assertNull(member.getUid());
+        member.setUid("jdoe");
+        assertThat(member.getUid(), is("jdoe"));
+    }
+
+    @Test
+    public void allArgsConstructor() {
+        OotbMember member = new OotbMember("Jane Doe", "87654321", "jadoe");
+        assertThat(member.getName(), is("Jane Doe"));
+        assertThat(member.getUhUuid(), is("87654321"));
+        assertThat(member.getUid(), is("jadoe"));
+    }
+
+    @Test
+    public void noArgsConstructor() {
+        OotbMember member = new OotbMember();
+        assertNull(member.getName());
+        assertNull(member.getUhUuid());
+        assertNull(member.getUid());
+    }
+}


### PR DESCRIPTION
# Ticket Link

[Ticket-1720](https://uhawaii.atlassian.net/browse/GROUPINGS-1720)

# List of squashed commits

- Create the type OotbGrouping, OotbMember and modify OotbActiveProfile class for API integration


- Modify the api end-point for making response entity with OotbActiveProfileResult by the api request with OotbActiveProfile from UI


- Implement the logic to add groupPath with 4 different extension (basis, include, exclude, owners) in getMembersResults to access grouping page


- Integrate addMember function with the function to update getMemberResults, getGroupsResults, and then make it responsive to extension of the groupPath that member added


- Implement changeAttribute function to make the member of specific groupPath allow and disallow self opt-in and opt-out by the checkbox in preference tab


- Implement manageAttributeAssignment to integrate the functions to update WsAttributeAssign and WsAttributeDefName in WsGetAttributeAssignmentsResults for all the members in specific groupPath to share the state of opt-in and opt-out allowance in multiple active profiles (replace changeAttribute with it)


- Implement getGroupAttributeResults with currentUser and groupPath to get the state of the checkbox in preference tab for current user


- Use the functions implemented in ootbGroupingPropertiesService for OotbGrouperApiService


- Remove updating time stamp in GroupingAttributeService when user uses OOTB active profile


- Add the test classes for the new types for ootb api specification


- Implement the function to extract extension of the groupPath in PathFilter class and add the test for it


- Modify the test for end-point in controller to update ootb active profile


- Modify one of the ootbGrouperApiServiceTest named testAssignAttributesResults for testing the new function for managing allowance of opt-in, opt-out of groupPath


- Organize the functions in OotbGroupingPropertiesService


- Organize with code style

- Modify the code with constructor injection

- Organize the code for codacy
- Modify the functions in service layer and add tests in various classes to improve coverage


- Fix naming with codacy analysis

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
