### PR TITLE
Call the API to remove membership that does not exist should not trigger a stack dump

### DIFF
--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingMoveMemberResult.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingMoveMemberResult.java
@@ -30,6 +30,13 @@ public class GroupingMoveMemberResult implements GroupingResult {
         setResultCode();
     }
 
+    public GroupingMoveMemberResult(String groupPath, String resultCode) {
+        addResult = new GroupingAddResult();
+        removeResult = new GroupingRemoveResult();
+        setGroupPath(groupPath);
+        this.resultCode = resultCode;
+    }
+
     @Override
     public String getResultCode() {
         return resultCode;

--- a/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
+++ b/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
@@ -230,6 +230,10 @@ public class UpdateMemberService {
         log.info(String.format("optIn; currentUser: %s; groupingPath: %s; uhIdentifier %s;",
                 currentUser, groupingPath, uhIdentifier));
         checkIfSelfOptOrAdmin(currentUser, uhIdentifier);
+        // To prevent a race condition and avoid calling the grouper API to update the status of someone who is already opted in
+        if(memberService.isInclude(groupingPath, uhIdentifier)) {
+            return new GroupingMoveMemberResult(groupingPath, "SUCCESS");
+        }
         return moveGroupMember(currentUser, groupingPath + GroupType.INCLUDE.value(),
                 groupingPath + GroupType.EXCLUDE.value(), uhIdentifier);
     }
@@ -238,6 +242,10 @@ public class UpdateMemberService {
         log.info(String.format("optOut; currentUser: %s; groupingPath: %s; uhIdentifier %s;",
                 currentUser, groupingPath, uhIdentifier));
         checkIfSelfOptOrAdmin(currentUser, uhIdentifier);
+        // To prevent a race condition and avoid calling the grouper API to update the status of someone who is already opted out
+        if(memberService.isExclude(groupingPath, uhIdentifier)) {
+            return new GroupingMoveMemberResult(groupingPath, "SUCCESS");
+        }
         return moveGroupMember(currentUser, groupingPath + GroupType.EXCLUDE.value(),
                 groupingPath + GroupType.INCLUDE.value(), uhIdentifier);
     }

--- a/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
@@ -111,7 +111,8 @@ public class UpdateMemberServiceTest {
 
         json = propertyLocator.find("ws.delete.member.results.success");
         WsDeleteMemberResults wsDeleteMemberResults = JsonUtil.asObject(json, WsDeleteMemberResults.class);
-        RemoveMemberResult removeMemberResult = new RemoveMemberResult(wsDeleteMemberResults.getResults()[0], groupPath);
+        RemoveMemberResult removeMemberResult =
+                new RemoveMemberResult(wsDeleteMemberResults.getResults()[0], groupPath);
         assertNotNull(removeMemberResult);
         doReturn(removeMemberResult).when(grouperService)
                 .removeMember(TEST_UIDS.get(1), GROUPING_ADMINS, TEST_UIDS.get(0));
@@ -158,7 +159,6 @@ public class UpdateMemberServiceTest {
 
         assertNotNull(updateMemberService.addOwnerships(TEST_UIDS.get(0), groupPath, TEST_UIDS));
     }
-
 
     @Test
     public void addOwnershipTest() {
@@ -248,7 +248,8 @@ public class UpdateMemberServiceTest {
 
         json = propertyLocator.find("ws.delete.member.results.failure");
         WsDeleteMemberResults wsDeleteMemberResults = JsonUtil.asObject(json, WsDeleteMemberResults.class);
-        RemoveMemberResult removeMemberResult = new RemoveMemberResult(wsDeleteMemberResults.getResults()[0], groupPath);
+        RemoveMemberResult removeMemberResult =
+                new RemoveMemberResult(wsDeleteMemberResults.getResults()[0], groupPath);
         String validIdentifier = subjectService.getValidUhUuid(TEST_UIDS.get(1));
         doReturn(removeMemberResult).when(grouperService)
                 .removeMember(TEST_UIDS.get(0), groupPath + GroupType.OWNERS.value(), validIdentifier);
@@ -443,12 +444,14 @@ public class UpdateMemberServiceTest {
 
     @Test
     public void optInTest() {
-        String json = propertyLocator.find("ws.has.member.results.is.members.uhuuid");
+        String json = propertyLocator.find("ws.has.member.results.is.members.uid");
         WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
         HasMembersResults hasMembersResults = new HasMembersResults(wsHasMemberResults);
         assertNotNull(hasMembersResults);
         doReturn(hasMembersResults).when(grouperService)
                 .hasMemberResults(groupPath + GroupType.OWNERS.value(), TEST_UIDS.get(0));
+        doReturn(hasMembersResults).when(grouperService)
+                .hasMemberResults(groupPath + GroupType.INCLUDE.value(), TEST_UIDS.get(1));
         doReturn(hasMembersResults).when(grouperService).hasMemberResults(GROUPING_ADMINS, TEST_UIDS.get(0));
 
         json = propertyLocator.find("ws.delete.member.results.failure");
@@ -473,12 +476,14 @@ public class UpdateMemberServiceTest {
 
     @Test
     public void optOutTest() {
-        String json = propertyLocator.find("ws.has.member.results.is.members.uhuuid");
+        String json = propertyLocator.find("ws.has.member.results.is.members.uid");
         WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
         HasMembersResults hasMembersResults = new HasMembersResults(wsHasMemberResults);
         assertNotNull(hasMembersResults);
         doReturn(hasMembersResults).when(grouperService)
                 .hasMemberResults(groupPath + GroupType.OWNERS.value(), TEST_UIDS.get(0));
+        doReturn(hasMembersResults).when(grouperService)
+                .hasMemberResults(groupPath + GroupType.EXCLUDE.value(), TEST_UIDS.get(1));
         doReturn(hasMembersResults).when(grouperService).hasMemberResults(GROUPING_ADMINS, TEST_UIDS.get(0));
 
         json = propertyLocator.find("ws.delete.member.results.failure");


### PR DESCRIPTION
# Ticket Link

[Ticket-1747](https://uhawaii.atlassian.net/browse/GROUPINGS-1747)

# List of squashed commits

- Add the logic to prevent a race condition in opt-in and out action and avoid calling the grouper API to update the status of someone who is already opted out

- Implement integrations test for checking the case of duplicated opt-in and opt-out commands and modify existed opt-in and opt-out unit tests

- Fix codacy analysis


# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
