### PR TITLE
Correct the logic to prevent a stack dump when removing membership

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
+++ b/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
@@ -243,7 +243,7 @@ public class UpdateMemberService {
                 currentUser, groupingPath, uhIdentifier));
         checkIfSelfOptOrAdmin(currentUser, uhIdentifier);
         // To prevent a race condition and avoid calling the grouper API to update the status of someone who is already opted out
-        if(memberService.isExclude(groupingPath, uhIdentifier)) {
+        if(!memberService.isInclude(groupingPath, uhIdentifier)) {
             return new GroupingMoveMemberResult(groupingPath, "SUCCESS");
         }
         return moveGroupMember(currentUser, groupingPath + GroupType.EXCLUDE.value(),

--- a/src/test/java/edu/hawaii/its/api/service/TestUpdateMemberService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestUpdateMemberService.java
@@ -481,7 +481,14 @@ public class TestUpdateMemberService {
             fail("should not throw an exception if user does self opt in when user already opted in");
         }
 
-        updateMemberService.removeIncludeMember(ADMIN, GROUPING, testUid);
+         try {
+            updateMemberService.removeIncludeMember(ADMIN, GROUPING, testUid);
+            updateMemberService.optIn(ADMIN, GROUPING, testUid);
+            assertTrue(memberService.isMember(GROUPING_INCLUDE, testUid));
+        } catch (CommandException e) {
+            fail("Should not throw an exception because opt in operation can be executed after removing include member");
+        }
+         updateMemberService.removeIncludeMember(ADMIN, GROUPING, testUid);
     }
 
     @Test
@@ -497,6 +504,14 @@ public class TestUpdateMemberService {
         }
 
         updateMemberService.removeExcludeMember(ADMIN, GROUPING, testUid);
+
+        try {
+            updateMemberService.removeIncludeMember(ADMIN, GROUPING, testUid);
+            updateMemberService.optOut(ADMIN, GROUPING, testUid);
+            assertFalse(memberService.isMember(GROUPING_EXCLUDE, testUid));
+        } catch (CommandException e) {
+            fail("Should not throw an exception because opt out operation is not executed after removing include member");
+        }
     }
 
     private void addGroupMember(String groupPath, String uhIdentifier) {

--- a/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
@@ -484,6 +484,8 @@ public class UpdateMemberServiceTest {
                 .hasMemberResults(groupPath + GroupType.OWNERS.value(), TEST_UIDS.get(0));
         doReturn(hasMembersResults).when(grouperService)
                 .hasMemberResults(groupPath + GroupType.EXCLUDE.value(), TEST_UIDS.get(1));
+        doReturn(hasMembersResults).when(grouperService)
+                .hasMemberResults(groupPath + GroupType.INCLUDE.value(), TEST_UIDS.get(1));
         doReturn(hasMembersResults).when(grouperService).hasMemberResults(GROUPING_ADMINS, TEST_UIDS.get(0));
 
         json = propertyLocator.find("ws.delete.member.results.failure");


### PR DESCRIPTION
# Ticket Link

[Ticket-1782](https://uhawaii.atlassian.net/browse/GROUPINGS-1782)

# List of squashed commits

- Modify the logic to prevent stack dump when multiple user opt-in and opt-out in the same time, Add mocking and some extra case for the tests

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
