### PR TITLE
Design configuration class for integration of HashiCorp Vault With Spring Boot Application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- Spring Vault -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-vault-config</artifactId>
+            <version>4.1.3</version>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/main/java/edu/hawaii/its/api/configuration/VaultConfig.java
+++ b/src/main/java/edu/hawaii/its/api/configuration/VaultConfig.java
@@ -1,0 +1,37 @@
+package edu.hawaii.its.api.configuration;
+
+import jakarta.annotation.PostConstruct;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+
+import edu.internet2.middleware.grouperClient.util.GrouperClientConfig;
+
+@Configuration
+@Profile("dockerhost")
+public class VaultConfig {
+
+    public static final Log log = LogFactory.getLog(VaultConfig.class);
+
+    @Value("${grouperClient.webService.password:}")
+    private String password;
+
+    @PostConstruct
+    public void init() {
+        if (password.equals("")) {
+            log.warn("Grouper client web service password from Vault is empty");
+            return;
+        }
+        GrouperClientConfig config = GrouperClientConfig.retrieveConfig();
+        setOverride(config, "grouperClient.webService.password", password);
+    }
+
+    private void setOverride(GrouperClientConfig config, String key, String value) {
+        if (value != null) {
+            config.propertiesOverrideMap().put(key, value);
+        }
+    }
+}

--- a/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
+++ b/src/main/java/edu/hawaii/its/api/controller/OotbRestController.java
@@ -1,0 +1,40 @@
+package edu.hawaii.its.api.controller;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import edu.hawaii.its.api.service.OotbGroupingPropertiesService;
+import edu.hawaii.its.api.type.OotbActiveProfile;
+import edu.hawaii.its.api.type.OotbActiveProfileResult;
+
+@RestController
+@Profile("ootb")
+@RequestMapping("/api/groupings/v2.1")
+public class OotbRestController {
+    private static final Log logger = LogFactory.getLog(OotbRestController.class);
+
+    private final OotbGroupingPropertiesService ootbGroupingPropertiesService;
+
+    // Constructor
+    public OotbRestController(OotbGroupingPropertiesService ootbGroupingPropertiesService) {
+        this.ootbGroupingPropertiesService = ootbGroupingPropertiesService;
+    }
+
+     /**
+     * Update Ootb active user profile.
+     */
+     @PostMapping(value = "/activeProfile/ootb")
+     public ResponseEntity<OotbActiveProfileResult> updateOotbActiveUserGroupings(@RequestBody
+     OotbActiveProfile ootbActiveProfile) {
+        logger.debug("Entered REST updateOotbActiveUserGroupings...");
+        return ResponseEntity
+                .ok()
+                .body(ootbGroupingPropertiesService.updateActiveUserProfile(ootbActiveProfile));
+     }
+}

--- a/src/main/resources/application-dockerhost.properties
+++ b/src/main/resources/application-dockerhost.properties
@@ -2,3 +2,9 @@
 # Docker host mappings.
 spring.config.activate.on-profile=dockerhost
 spring.config.import=optional:file:/overrides/uh-groupings-api-overrides.properties
+
+# =========================================================================
+# Vault Settings
+spring.cloud.vault.uri=https://localhost:8200
+spring.cloud.vault.connection-timeout=5000
+spring.cloud.vault.read-timeout=15000

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -88,4 +88,8 @@ logging.level.edu.hawaii.its.api=DEBUG
 logging.level.org.springframework=WARN
 
 # =========================================================================
+# Vault Settings.
+spring.cloud.vault.enabled=false
+
+# =========================================================================
 app.environment=dev

--- a/src/test/java/edu/hawaii/its/api/configuration/VaultConfigTest.java
+++ b/src/test/java/edu/hawaii/its/api/configuration/VaultConfigTest.java
@@ -1,0 +1,59 @@
+package edu.hawaii.its.api.configuration;
+
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import edu.internet2.middleware.grouperClient.util.GrouperClientConfig;
+
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+@TestPropertySource(properties = { "grouperClient.webService.password=grouperPassword" })
+@ActiveProfiles("dockerhost")
+public class VaultConfigTest {
+
+    @Autowired
+    private VaultConfig vaultConfig;
+
+    @Test
+    public void construction() {
+        assertNotNull(vaultConfig);
+    }
+
+    @Test
+    public void testingOverrideProperty() {
+        GrouperClientConfig config = GrouperClientConfig.retrieveConfig();
+
+        String key = "grouperClient.webService.password";
+        String testUrl = "grouperPassword";
+
+        vaultConfig.init();
+
+        String overriddenValue = config.propertiesOverrideMap().get(key);
+        assertThat(overriddenValue, equalTo(testUrl));
+    }
+
+    @Test
+    public void testEnvironmentVariableOverride() {
+        MockEnvironment mockEnv = new MockEnvironment();
+        mockEnv.setProperty("grouperClient.webService.password", "grouperPassword");
+
+        GrouperPropertyConfigurer configurerWithMockEnv = new GrouperPropertyConfigurer();
+        ReflectionTestUtils.setField(configurerWithMockEnv, "webServicePassword",
+                mockEnv.getProperty("grouperClient.webService.password"));
+
+        configurerWithMockEnv.init();
+
+        GrouperClientConfig config = GrouperClientConfig.retrieveConfig();
+
+        String overriddenValue = config.propertiesOverrideMap().get("grouperClient.webService.password");
+        assertThat(overriddenValue, equalTo("grouperPassword"));
+    }
+}

--- a/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
+++ b/src/test/java/edu/hawaii/its/api/controller/OotbRestControllerTest.java
@@ -1,0 +1,97 @@
+package edu.hawaii.its.api.controller;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.setup.MockMvcBuilders.webAppContextSetup;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
+import org.springframework.web.context.WebApplicationContext;
+
+import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.service.OotbGroupingPropertiesService;
+import edu.hawaii.its.api.type.OotbActiveProfile;
+import edu.hawaii.its.api.type.OotbActiveProfileResult;
+import edu.hawaii.its.api.util.JsonUtil;
+
+@SpringBootTest(classes = { SpringBootWebApplication.class })
+@ActiveProfiles("ootb")
+public class OotbRestControllerTest {
+
+    private static final String API_BASE = "/api/groupings/v2.1";
+    private static final String GROUPING = "path:to:grouping";
+    private static final String UID = "user";
+    private static final String ADMIN = "admin";
+    @Value("${groupings.api.current_user}")
+    private String CURRENT_USER;
+    @Value("${groupings.api.success}")
+    private String SUCCESS;
+    @MockBean
+    private OotbGroupingPropertiesService ootbGroupingPropertiesService;
+    @Autowired
+    private WebApplicationContext context;
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    public void setUp() {
+        mockMvc = webAppContextSetup(context).build();
+    }
+
+    @Test
+    public void updateActiveDefaultUserTest() throws Exception {
+        List<String> paths = Arrays.asList("ROLE_ADMIN", "ROLE_UH", "ROLE_OWNER");
+
+        OotbActiveProfile activeProfile = new OotbActiveProfile();
+        activeProfile.setUid("admin0123");
+        activeProfile.setUhUuid("33333333");
+        activeProfile.setAuthorities(paths);
+        activeProfile.setAttributes(new HashMap<>());
+        activeProfile.setGroupings(new ArrayList<>());
+
+        OotbActiveProfileResult expectedResult = new OotbActiveProfileResult(activeProfile);
+
+        given(ootbGroupingPropertiesService.updateActiveUserProfile(argThat(profile ->
+                profile.getUid().equals(activeProfile.getUid()) &&
+                        profile.getUhUuid().equals(activeProfile.getUhUuid()) &&
+                        profile.getAuthorities().equals(activeProfile.getAuthorities()) &&
+                        profile.getAttributes().equals(activeProfile.getAttributes()) &&
+                        profile.getGroupings().equals(activeProfile.getGroupings())
+        ))).willReturn(expectedResult);
+
+        MvcResult result = mockMvc.perform(
+                        post(API_BASE + "/activeProfile/ootb")
+                                .header(CURRENT_USER, CURRENT_USER)
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(JsonUtil.asJson(activeProfile)))
+                .andExpect(status().isOk())
+                .andReturn();
+
+        assertNotNull(result);
+        verify(ootbGroupingPropertiesService, times(1))
+                .updateActiveUserProfile(argThat(profile ->
+                        profile.getUid().equals(activeProfile.getUid()) &&
+                                profile.getUhUuid().equals(activeProfile.getUhUuid()) &&
+                                profile.getAuthorities().equals(activeProfile.getAuthorities()) &&
+                                profile.getAttributes().equals(activeProfile.getAttributes()) &&
+                                profile.getGroupings().equals(activeProfile.getGroupings())
+                ));
+    }
+}


### PR DESCRIPTION
# Ticket Link

[Ticket-1833](https://uhawaii.atlassian.net/browse/GROUPINGS-1833)

# List of squashed commits

- Implement VaultConfig using spring cloud vault
- Fix bean creation error of VaultConfig and completly separate existed local dev environment and docker for running on the both, and modify the tests for vault config class
- Fix code style
- Update the version of dependencies for cloud vault config after checking compatibility with current spring boot version
- Make extra configs to manage the environments that doesn't have active vault on the localhost or dockerhost
- Remove vault core dependency from pom.xml
-  Move token property from source code to docker compose to avoid the situation that
 develoepr push the code with token by mistake, and disable vault in the localhost for the people who don't want to auto create vault bean without installing vault in their os
- Fix property of injection value in the vault config from the secret engine of the vaule



# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
