### PR TITLE
Implement functions for mocking all the grouper results of OOTB tests class with the JSON file for each active profile

### DIFF
--- a/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
+++ b/src/main/java/edu/hawaii/its/api/util/JsonUtil.java
@@ -1,8 +1,13 @@
 package edu.hawaii.its.api.util;
 
+import java.nio.file.Files;
 import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public class JsonUtil {
@@ -28,7 +33,7 @@ public class JsonUtil {
         try {
             result = new ObjectMapper().readValue(json, type);
         } catch (Exception e) {
-            logger.error("Error: " + type +"; " + e);
+            logger.error("Error: " + type + "; " + e);
         }
         return result;
     }
@@ -42,6 +47,31 @@ public class JsonUtil {
             logger.error("Error: " + e);
         }
         return result;
+    }
+
+    private static String readJsonFileToString(String filePath) {
+        String result = null;
+        try {
+            if (!filePath.endsWith(".json")) {
+                throw new IllegalArgumentException("The provided file is not a JSON file: " + filePath);
+            }
+            Resource resource = new ClassPathResource(filePath);
+            result = Files.readString(resource.getFile().toPath());
+        } catch (IllegalArgumentException e) {
+            logger.error("Invalid file error: " + e.getMessage());
+            throw e;
+        } catch (Exception e) {
+            logger.error("Error: " + e);
+        }
+        return result;
+    }
+
+    public static <T> List<T> asListFromFile(final String filePath, Class<T> type) {
+        return JsonUtil.asList(readJsonFileToString(filePath), type);
+    }
+
+    public static <T> T asObjectFromFile(final String filePath, Class<T> type) {
+        return JsonUtil.asObject(readJsonFileToString(filePath), type);
     }
 
     public static void printJson(Object obj) {

--- a/src/test/java/edu/hawaii/its/api/configuration/GroupingsTestConfiguration.java
+++ b/src/test/java/edu/hawaii/its/api/configuration/GroupingsTestConfiguration.java
@@ -1,10 +1,13 @@
 package edu.hawaii.its.api.configuration;
 
+import java.util.List;
+
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.springframework.boot.test.context.TestConfiguration;
 
 import edu.hawaii.its.api.groupings.GroupingSyncDestination;
+import edu.hawaii.its.api.type.OotbActiveProfile;
 import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.PropertyLocator;
 import edu.hawaii.its.api.wrapper.AddMemberResult;
@@ -50,6 +53,10 @@ public class GroupingsTestConfiguration {
     private <T> T getWsResultTestData(String propertyName, Class<T> type) {
         String json = propertyLocator.find(propertyName);
         return JsonUtil.asObject(json, type);
+    }
+
+    public List<OotbActiveProfile> ootbActiveProfilesTestData() {
+        return JsonUtil.asListFromFile("ootb.active.user.profiles.json", OotbActiveProfile.class);
     }
 
     public HasMembersResults hasMemberResultsIsMembersUidTestData() {

--- a/src/test/java/edu/hawaii/its/api/service/OotbGroupingPropertiesServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/OotbGroupingPropertiesServiceTest.java
@@ -8,12 +8,16 @@ import java.util.List;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import edu.hawaii.its.api.configuration.GroupingsTestConfiguration;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.type.GroupingTest;
+import edu.hawaii.its.api.type.OotbActiveProfile;
 import edu.hawaii.its.api.wrapper.AddMembersResults;
 import edu.hawaii.its.api.wrapper.AssignAttributesResults;
 import edu.hawaii.its.api.wrapper.FindGroupsResults;
@@ -37,9 +41,21 @@ class OotbGroupingPropertiesServiceTest {
     @Autowired
     private OotbGroupingPropertiesService ootbGroupingPropertiesService;
 
+    @Autowired
+    private GroupingsTestConfiguration groupingsTestConfiguration;
+
+    @Mock
+    private List<OotbActiveProfile> ootbActiveProfiles;
+
     @BeforeEach
     public void setUp() {
         MockitoAnnotations.openMocks(this);
+        ootbActiveProfiles = groupingsTestConfiguration.ootbActiveProfilesTestData();
+    }
+
+    @Test
+    public void testOotbActiveProfiles() {
+        assertNotNull(ootbActiveProfiles);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/util/JsonUtilTest.java
+++ b/src/test/java/edu/hawaii/its/api/util/JsonUtilTest.java
@@ -3,20 +3,28 @@ package edu.hawaii.its.api.util;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
+import java.io.FileNotFoundException;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import edu.hawaii.its.api.type.OotbActiveProfile;
 import edu.hawaii.its.api.wrapper.Subject;
 
 import edu.internet2.middleware.grouperClient.ws.beans.WsSubject;
+
 public class JsonUtilTest {
 
     private static PropertyLocator propertyLocator;
@@ -86,4 +94,36 @@ public class JsonUtilTest {
         constructor.newInstance();
     }
 
+    @Test
+    public void asObjectFromFile() {
+        TestUser user = JsonUtil.asObjectFromFile("test.json", TestUser.class);
+        assertNotNull(user);
+        assertTrue(user.getTest().equals("value"));
+        assertEquals(123, user.getNumber());
+
+        assertNull(JsonUtil.asObjectFromFile("non-existent.json", TestUser.class));
+    }
+
+    @Test
+    public void asListFromFile() {
+        List<OotbActiveProfile> users =
+                JsonUtil.asListFromFile("ootb.active.user.profiles.json", OotbActiveProfile.class);
+        assertNotNull(users);
+
+        assertNull(JsonUtil.asListFromFile("non-existent.json", TestUser.class));
+    }
+
+    // Test class matching test.json structure
+    private static class TestUser {
+        private String test;
+        private int number;
+
+        public String getTest() {
+            return test;
+        }
+
+        public int getNumber() {
+            return number;
+        }
+    }
 }

--- a/src/test/resources/test.json
+++ b/src/test/resources/test.json
@@ -1,0 +1,1 @@
+{"test": "value", "number": 123}


### PR DESCRIPTION
# Ticket Link

[Ticket-1812](https://uhawaii.atlassian.net/browse/GROUPINGS-1812)

# List of squashed commits

- Add the function in JsonUtil to read json file and convert it to string for mapping to the class, and make the test for it

- Implement the mapping logic for List<OotbActiveProfile> in test configuration class and use it in the OotbGroupingPropertiesServiceTest
- Separate function to map object and list of object from file using existed JsonUtil function
- Add throw error logic when the file is not json or when json file has problem


# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
