### PR TITLE
Combines searchGroupingMembers and getGroupingMembers endpoints

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -305,25 +305,13 @@ public class GroupingsRestControllerv2_1 {
                                                                    @RequestParam(required = false) Integer page,
                                                                    @RequestParam(required = false) Integer size,
                                                                    @RequestParam(required = true) SortBy sortBy,
-                                                                   @RequestParam Boolean isAscending) {
+                                                                   @RequestParam Boolean isAscending,
+                                                                   @RequestParam(required = false) String searchString) {
         logger.info("Entered REST getGroupingMembers...");
         return ResponseEntity
                 .ok()
                 .body(groupingOwnerService
-                        .getGroupingMembers(currentUser, groupingPath, page, size, sortBy.sortString(), isAscending));
-    }
-
-    /**
-     * Get grouping members of a selected grouping path by search string.
-     */
-    @GetMapping(value = "/groupings/{path:[\\w-:.]+}/search/{search}")
-    public ResponseEntity<GroupingGroupMembers> searchGroupingMembers(
-            @RequestHeader(CURRENT_USER_KEY) String currentUser,
-            @PathVariable String path, @PathVariable String search) {
-        logger.info("Entered REST searchGroupingMembers");
-        return ResponseEntity
-                .ok()
-                .body(groupingOwnerService.groupingMembersBySearchString(currentUser, path, search));
+                        .getGroupingMembers(currentUser, groupingPath, page, size, sortBy.sortString(), isAscending, searchString));
     }
 
     /**
@@ -721,7 +709,7 @@ public class GroupingsRestControllerv2_1 {
         logger.info("Enter REST getNumberOfGroupingMembers...");
         return ResponseEntity
                 .ok()
-                .body(groupingsService.numberOfGroupingMembers(currentUser, path));
+                .body(groupingOwnerService.numberOfGroupingMembers(currentUser, path));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -1,7 +1,9 @@
 package edu.hawaii.its.api.groupings;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.Subject;
@@ -14,6 +16,7 @@ import edu.hawaii.its.api.wrapper.SubjectsResults;
 public class GroupingGroupMembers implements GroupingResult {
     private String resultCode;
     private String groupPath;
+    private int size;
 
     private List<GroupingGroupMember> members;
 
@@ -21,18 +24,28 @@ public class GroupingGroupMembers implements GroupingResult {
         setResultCode(getMembersResult.getResultCode());
         setGroupPath(getMembersResult.getGroup().getGroupPath());
         setMembers(getMembersResult.getSubjects());
+        setSize(members.size());
     }
 
     public GroupingGroupMembers(SubjectsResults subjectsResults) {
         setResultCode(subjectsResults.getResultCode());
         setGroupPath(subjectsResults.getGroup().getGroupPath());
         setMembers(subjectsResults.getSubjects());
+        setSize(members.size());
     }
 
     public GroupingGroupMembers() {
         setResultCode("");
         setGroupPath("");
         setMembers(new ArrayList<>());
+        setSize(0);
+    }
+
+    private GroupingGroupMembers(GroupingGroupMembers other) {
+        this.resultCode = other.resultCode;
+        this.groupPath = other.groupPath;
+        this.size = other.size;
+        this.members = other.members;
     }
 
     @Override public String getResultCode() {
@@ -51,6 +64,18 @@ public class GroupingGroupMembers implements GroupingResult {
         this.groupPath = groupPath;
     }
 
+    public int getSize() {
+        return size;
+    }
+
+    public void setSize(int size) {
+        this.size = size;
+    }
+
+    public List<GroupingGroupMember> getMembers() {
+        return this.members;
+    }
+
     public void setMembers(List<Subject> subjects) {
         this.members = new ArrayList<>();
         for (Subject subject : subjects) {
@@ -58,7 +83,29 @@ public class GroupingGroupMembers implements GroupingResult {
         }
     }
 
-    public List<GroupingGroupMember> getMembers() {
-        return this.members;
+    public GroupingGroupMembers sort(String sortString, boolean isAscending) {
+        Map<String, Comparator<GroupingGroupMember>> comparatorMap = Map.of(
+                "name", Comparator.comparing(GroupingGroupMember::getName),
+                "search_string0", Comparator.comparing(GroupingGroupMember::getUid),
+                "subjectId", Comparator.comparing(GroupingGroupMember::getUhUuid)
+        );
+        Comparator<GroupingGroupMember> comparator = comparatorMap.get(sortString);
+
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
+        groupingGroupMembers.members.sort(isAscending ? comparator : comparator.reversed());
+
+        return groupingGroupMembers;
+    }
+
+    public GroupingGroupMembers paginate(int pageNumber, int pageSize) {
+        int fromIndex = (pageNumber - 1) * pageSize;
+        int toIndex = Math.min(fromIndex + pageSize, members.size());
+
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
+        groupingGroupMembers.members = fromIndex < toIndex
+                ? members.subList(fromIndex, toIndex)
+                : new ArrayList<>();
+
+        return groupingGroupMembers;
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
@@ -3,6 +3,9 @@ package edu.hawaii.its.api.service;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+
 import edu.hawaii.its.api.wrapper.AddMemberResult;
 import edu.hawaii.its.api.wrapper.AddMembersCommand;
 import edu.hawaii.its.api.wrapper.AddMembersResults;
@@ -116,10 +119,11 @@ public class GrouperApiService implements GrouperService {
     /**
      * Get a list of members for a specific grouping path with search string
      */
-    public SubjectsResults getSubjects(String groupingPath, String SearchString) {
+    @Cacheable("search")
+    public SubjectsResults getSubjects(String groupingPath, String searchString) {
         SubjectsResults subjectsResults = exec.execute(new SubjectsCommand()
                 .assignGroupingPath(groupingPath)
-                .assignSearchString(SearchString));
+                .assignSearchString(searchString));
         return subjectsResults;
     }
 
@@ -267,6 +271,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Add a UH identifier to group listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public AddMemberResult addMember(String currentUser, String groupPath, String uhIdentifier) {
         return exec.execute(new AddMembersCommand()
                 .owner(currentUser)
@@ -277,6 +282,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Add multiple UH identifiers to a group listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public AddMembersResults addMembers(String currentUser, String groupPath, List<String> uhIdentifiers) {
         return exec.execute(new AddMembersCommand()
                 .owner(currentUser)
@@ -287,6 +293,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Add multiple path owners to a group owner listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public AddMembersResults addGroupPathOwners(String currentUser, String groupPath, List<String> groupPathOwners) {
         return exec.execute(new AddMembersCommand()
                 .owner(currentUser)
@@ -297,6 +304,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Remove a UH identifier from a group listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public RemoveMemberResult removeMember(String currentUser, String groupPath, String uhIdentifier) {
         return exec.execute(new RemoveMembersCommand()
                 .owner(currentUser)
@@ -307,6 +315,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Remove multiple UH identifiers from a group listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public RemoveMembersResults removeMembers(String currentUser, String groupPath, List<String> uhIdentifiers) {
         return exec.execute(new RemoveMembersCommand()
                 .owner(currentUser)
@@ -317,6 +326,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Remove multiple path owners from a group owner listing.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public RemoveMembersResults removeGroupPathOwners(String currentUser, String groupPath,
             List<String> groupPathOwners) {
         return exec.execute(new RemoveMembersCommand()
@@ -328,6 +338,7 @@ public class GrouperApiService implements GrouperService {
     /**
      * Remove all listed members from a group.
      */
+    @CacheEvict(value="search", key="#groupPath")
     public AddMembersResults resetGroupMembers(String groupPath) {
         return exec.execute(new AddMembersCommand()
                 .assignGroupPath(groupPath)

--- a/src/main/java/edu/hawaii/its/api/service/GrouperService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperService.java
@@ -35,7 +35,7 @@ public interface GrouperService {
 
     SubjectsResults getSubjects(List<String> uhIdentifiers);
 
-    SubjectsResults getSubjects(String groupingPath, String SearchString);
+    SubjectsResults getSubjects(String groupingPath, String searchString);
 
     GroupAttributeResults groupAttributeResults(String attribute);
 

--- a/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
@@ -1,6 +1,5 @@
 package edu.hawaii.its.api.service;
 
-import static edu.hawaii.its.api.service.PathFilter.logger;
 import static edu.hawaii.its.api.service.PathFilter.parentGroupingPath;
 import static edu.hawaii.its.api.service.PathFilter.pathHasOwner;
 import static edu.hawaii.its.api.service.PathFilter.removeDuplicates;
@@ -18,7 +17,6 @@ import org.springframework.stereotype.Service;
 import edu.hawaii.its.api.groupings.GroupingUpdateDescriptionResult;
 import edu.hawaii.its.api.type.GroupingPath;
 import edu.hawaii.its.api.type.OptType;
-import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.Group;
 import edu.hawaii.its.api.wrapper.GroupAttribute;
 import edu.hawaii.its.api.wrapper.GroupAttributeResults;
@@ -178,14 +176,5 @@ public class GroupingsService {
     public List<String> allGroupPaths(String uhIdentifier) {
         List<Group> groups = grouperService.getGroupsResults(uhIdentifier).getGroups();
         return groups.stream().map(Group::getGroupPath).collect(Collectors.toList());
-    }
-
-    /**
-     * Get the number of grouping members
-     */
-    public Integer numberOfGroupingMembers(String currentUser, String path) {
-        logger.debug(String.format("numberOfGroupingMembers; currentUser: %s; path: %s;", currentUser, path));
-        GetMembersResult getMembersResult = grouperService.getMembersResult(currentUser, path);
-        return getMembersResult.getSubjects().size();
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
@@ -89,7 +89,7 @@ public class OotbGrouperApiService implements GrouperService {
         return ootbGroupingPropertiesService.getSubjects(uhIdentifiers);
     }
 
-    public SubjectsResults getSubjects(String groupingPath, String SearchString){
+    public SubjectsResults getSubjects(String groupingPath, String searchString) {
         return ootbGroupingPropertiesService.getSubject(groupingPath);
     }
 

--- a/src/main/java/edu/hawaii/its/api/type/OptType.java
+++ b/src/main/java/edu/hawaii/its/api/type/OptType.java
@@ -1,5 +1,7 @@
 package edu.hawaii.its.api.type;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum OptType {
 
     IN("uh-settings:attributes:for-groups:uh-grouping:anyone-can:opt-in", InclusionType.IN),
@@ -13,6 +15,7 @@ public enum OptType {
         this.inclusionType = inclusionType;
     }
 
+    @JsonValue
     public String value() {
         return value;
     }

--- a/src/main/java/edu/hawaii/its/api/type/SortBy.java
+++ b/src/main/java/edu/hawaii/its/api/type/SortBy.java
@@ -3,14 +3,12 @@ package edu.hawaii.its.api.type;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum SortBy {
-
     NAME("name", "name"),
     UID("uid", "search_string0"),
     UH_UUID("uhUuid", "subjectId");
 
     private final String value;
     private final String sortString;
-
 
     SortBy(String value, String sortString) {
         this.value = value;
@@ -20,7 +18,6 @@ public enum SortBy {
 
     @JsonValue
     public String value() {
-
         return value;
     }
 

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -414,7 +414,7 @@ public class GroupingsRestControllerv2_1Test {
         GetMembersResults getMembersResults = new GetMembersResults(wsGetMembersResults);
         GroupingGroupsMembers groupingGroupsMembers = new GroupingGroupsMembers(getMembersResults);
         List<String> paths = Arrays.asList("group-path:basis", "group-path:include", "group-path:exclude", "group-path:owners");
-        for (SortBy sortBy: sortByOptions) {
+        for (SortBy sortBy : sortByOptions) {
             given(groupingOwnerService.paginatedGrouping(CURRENT_USER, paths, 1, 700, sortBy.sortString(), true))
                 .willReturn(groupingGroupsMembers);
             MvcResult result = mockMvc.perform(
@@ -431,36 +431,28 @@ public class GroupingsRestControllerv2_1Test {
 
     @Test
     public void getGroupingMembersTest() throws Exception {
+        SortBy[] sortByOptions = { SortBy.NAME, SortBy.UID, SortBy.UH_UUID };
         String json = propertyLocator.find("ws.get.members.results.success");
         WsGetMembersResult wsGetMembersResult = JsonUtil.asObject(json, WsGetMembersResult.class);
         GetMembersResult getMembersResult = new GetMembersResult(wsGetMembersResult);
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(getMembersResult);
         assertNotNull(groupingGroupMembers);
         String path = "group-path:include";
-        given(groupingOwnerService.getGroupingMembers(CURRENT_USER, path, 1, 700, "name", true))
-                .willReturn(groupingGroupMembers);
-        MvcResult result = mockMvc.perform(
-                        get(API_BASE + "/groupings/" + path + "?page=1&size=700&sortBy=name&isAscending=true")
-                                .header(CURRENT_USER, CURRENT_USER))
-                .andExpect(status().isOk())
-                .andReturn();
-        assertNotNull(result);
-        assertEquals(JsonUtil.asJson(groupingGroupMembers), result.getResponse().getContentAsString());
-        verify(groupingOwnerService, times(1))
-                .getGroupingMembers(CURRENT_USER, path, 1, 700, "name", true);
-    }
+        for (SortBy sortBy : sortByOptions) {
+            given(groupingOwnerService.getGroupingMembers(CURRENT_USER, path, 1, 700,
+                    sortBy.sortString(), true, "test")).willReturn(groupingGroupMembers);
+            MvcResult result = mockMvc.perform(
+                            get(API_BASE + "/groupings/" + path + "?page=1&size=700&sortBy=" + sortBy.value()
+                                    + "&isAscending=true&searchString=test")
+                                    .header(CURRENT_USER, CURRENT_USER))
+                    .andExpect(status().isOk())
+                    .andReturn();
+            assertNotNull(result);
+            assertEquals(JsonUtil.asJson(groupingGroupMembers), result.getResponse().getContentAsString());
+            verify(groupingOwnerService, times(1)).getGroupingMembers(CURRENT_USER, path,
+                    1, 700, sortBy.sortString(), true, "test");
+        }
 
-    @Test
-    public void searchGroupingMembersTest() throws Exception {
-        String path = "path:to:grouping";
-        String search = "UID";
-        given(memberService.isAdmin(ADMIN)).willReturn(true);
-        given(groupingOwnerService.groupingMembersBySearchString(ADMIN, path, search)).willReturn(new GroupingGroupMembers());
-        MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + path + "/search/" + search)
-                        .header(CURRENT_USER, ADMIN))
-                .andExpect(status().isOk()).andReturn();
-        assertNotNull(mvcResult);
-        verify(groupingOwnerService, times(1)).groupingMembersBySearchString(ADMIN, path, search);
     }
 
     @Test
@@ -935,7 +927,7 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     public void getNumberOfGroupingMembersTest() throws Exception {
         String path = "grouping-path";
-        given(groupingsService.numberOfGroupingMembers(ADMIN, path))
+        given(groupingOwnerService.numberOfGroupingMembers(ADMIN, path))
                 .willReturn(100);
 
         mockMvc.perform(get(API_BASE + "/groupings/" + path + "/count")
@@ -943,7 +935,7 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(status().isOk())
                 .andExpect(content().string("100"));
 
-        verify(groupingsService, times(1))
+        verify(groupingOwnerService, times(1))
                 .numberOfGroupingMembers(ADMIN, path);
     }
 

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -17,7 +17,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import edu.hawaii.its.api.type.SortBy;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
@@ -58,6 +57,7 @@ import edu.hawaii.its.api.service.UhIdentifierGenerator;
 import edu.hawaii.its.api.service.UpdateMemberService;
 import edu.hawaii.its.api.type.AsyncJobResult;
 import edu.hawaii.its.api.type.OptType;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.util.JsonUtil;
 
 @ActiveProfiles("integrationTest")
@@ -377,7 +377,8 @@ public class TestGroupingsRestControllerv2_1 {
     public void getGroupingMembersTest() throws Exception {
         SortBy[] sortByOptions = { SortBy.NAME, SortBy.UID, SortBy.UH_UUID };
         for(SortBy sortBy: sortByOptions){
-            String url = API_BASE_URL + "groupings/group?sortBy=" + sortBy.value() + "&page=1&size=700&isAscending=true";
+            String url = API_BASE_URL + "groupings/group?sortBy=" + sortBy.value()
+                    + "&page=1&size=700&isAscending=true&searchString=test";
             List<String> paths = Arrays.asList(GROUPING_INCLUDE, GROUPING_EXCLUDE, GROUPING_OWNERS);
             MvcResult mvcResult = mockMvc.perform(post(url)
                             .header(CURRENT_USER, ADMIN)
@@ -390,18 +391,6 @@ public class TestGroupingsRestControllerv2_1 {
                     objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingGroupsMembers.class));
         }
 
-    }
-
-    @Test
-    public void searchGroupingMembersTest() throws Exception {
-        String search = "search";
-        String url = API_BASE_URL + "groupings/" + GROUPING + "/search/" + search;
-        MvcResult mvcResult = mockMvc.perform(get(url)
-                        .header(CURRENT_USER, ADMIN))
-                .andExpect(status().isOk())
-                .andReturn();
-        assertNotNull(mvcResult);
-        assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingGroupMembers.class));
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
@@ -1,8 +1,10 @@
 package edu.hawaii.its.api.groupings;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -11,6 +13,7 @@ import org.junit.jupiter.api.Test;
 import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.PropertyLocator;
 import edu.hawaii.its.api.wrapper.GetMembersResults;
+import edu.hawaii.its.api.wrapper.Subject;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
 
 import edu.internet2.middleware.grouperClient.ws.beans.WsGetMembersResults;
@@ -26,6 +29,16 @@ public class GroupingGroupMembersTest {
     }
 
     @Test
+    public void testDefaultConstructor() {
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers();
+        assertNotNull(groupingGroupMembers);
+        assertEquals("", groupingGroupMembers.getResultCode());
+        assertEquals("", groupingGroupMembers.getGroupPath());
+        assertEquals(new ArrayList<>(), groupingGroupMembers.getMembers());
+        assertEquals(0, groupingGroupMembers.getSize());
+    }
+
+    @Test
     public void testConstructorWithGetMembersResults() {
         String json = propertyLocator.find("ws.get.members.results.success");
         WsGetMembersResults wsGetMembersResults = JsonUtil.asObject(json, WsGetMembersResults.class);
@@ -37,7 +50,7 @@ public class GroupingGroupMembersTest {
         assertEquals("SUCCESS", groupingGroupMembers.getResultCode());
         List<GroupingGroupMember> results = groupingGroupMembers.getMembers();
         assertNotNull(results);
-        assertEquals(2, results.size());
+        assertEquals(groupingGroupMembers.getSize(), results.size());
     }
 
     @Test
@@ -50,6 +63,53 @@ public class GroupingGroupMembersTest {
         assertEquals("SUCCESS", groupingGroupMembers.getResultCode());
         List<GroupingGroupMember> results = groupingGroupMembers.getMembers();
         assertNotNull(results);
-        assertEquals(4, results.size());
+        assertEquals(groupingGroupMembers.getSize(), results.size());
+    }
+
+    @Test
+    public void testSort() {
+        String json = propertyLocator.find("ws.get.members.results.success");
+        WsGetMembersResults wsGetMembersResults = JsonUtil.asObject(json, WsGetMembersResults.class);
+        GetMembersResults getMembersResults = new GetMembersResults(wsGetMembersResults);
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(getMembersResults.getMembersResults()
+                .get(0));
+        assertNotNull(groupingGroupMembers);
+        List<GroupingGroupMember> members = groupingGroupMembers.getMembers();
+        GroupingGroupMember firstMember = members.get(0);
+        GroupingGroupMember secondMember = members.get(1);
+
+        groupingGroupMembers = groupingGroupMembers.sort("name", false);
+        assertEquals(firstMember.getName(), groupingGroupMembers.getMembers().get(1).getName());
+        assertEquals(secondMember.getName(), groupingGroupMembers.getMembers().get(0).getName());
+
+        groupingGroupMembers = groupingGroupMembers.sort("search_string0", true);
+        assertEquals(firstMember.getUid(), groupingGroupMembers.getMembers().get(0).getUid());
+        assertEquals(secondMember.getUid(), groupingGroupMembers.getMembers().get(1).getUid());
+
+        groupingGroupMembers = groupingGroupMembers.sort("subjectId", false);
+        assertEquals(firstMember.getUhUuid(), groupingGroupMembers.getMembers().get(1).getUhUuid());
+        assertEquals(secondMember.getUhUuid(), groupingGroupMembers.getMembers().get(0).getUhUuid());
+    }
+
+    @Test
+    public void testPaginate() {
+        String json = propertyLocator.find("ws.get.subjects.results.success");
+        WsGetSubjectsResults wsGetSubjectsResults = JsonUtil.asObject(json, WsGetSubjectsResults.class);
+        SubjectsResults subjectsResults = new SubjectsResults(wsGetSubjectsResults);
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(subjectsResults);
+        assertNotNull(groupingGroupMembers);
+        List<Subject> subjects = subjectsResults.getSubjects();
+        for (int i = 0; i < 3; i++) {
+            List<Subject> duplicateSubjects = new ArrayList<>(subjects);
+            subjects.addAll(duplicateSubjects);
+        }
+        groupingGroupMembers.setMembers(subjects);
+
+        assertEquals(20, groupingGroupMembers.paginate(1, 20).getMembers().size());
+        assertEquals(12, groupingGroupMembers.paginate(2, 20).getMembers().size());
+        assertEquals(0, groupingGroupMembers.paginate(3, 20).getMembers().size());
+        assertEquals(0, groupingGroupMembers.paginate(10, 20).getMembers().size());
+        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(-1, 20));
+        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(0, 20));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingsService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingsService.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.TestInstance;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
@@ -49,9 +48,6 @@ public class TestGroupingsService extends ServiceTest {
 
     @Autowired
     private GroupingsService groupingsService;
-
-    @MockitoSpyBean
-    private GrouperService grouperService;
 
     private static String UH_UUID;
 
@@ -151,23 +147,6 @@ public class TestGroupingsService extends ServiceTest {
         assertEquals("SUCCESS_UPDATED", result.getResultCode());
         assertEquals(updatedDescription, result.getCurrentDescription());
         assertEquals(description, result.getUpdatedDescription());
-    }
-
-    @Test
-    public void getNumberOfGroupingMembersTest() {
-        int initialCount = groupingsService.numberOfGroupingMembers(ADMIN, GROUPING_INCLUDE);
-
-        grouperService.addMember(ADMIN, GROUPING_INCLUDE, TEST_UH_UUIDS.get(1));
-        int countAfterAddition = groupingsService.numberOfGroupingMembers(ADMIN, GROUPING_INCLUDE);
-        assertEquals(initialCount + 1, countAfterAddition);
-
-        grouperService.removeMember(ADMIN, GROUPING_INCLUDE, TEST_UH_UUIDS.get(1));
-        int countAfterRemoval = groupingsService.numberOfGroupingMembers(ADMIN, GROUPING_INCLUDE);
-        assertEquals(initialCount, countAfterRemoval);
-
-        grouperService.resetGroupMembers(GROUPING_INCLUDE);
-        int emptyCount = groupingsService.numberOfGroupingMembers(ADMIN, GROUPING_INCLUDE);
-        assertEquals(0, emptyCount);
     }
 
 }


### PR DESCRIPTION
# Ticket Link

[GROUPINGS-1863](https://uhawaii.atlassian.net/browse/GROUPINGS-1863)

# List of squashed commits

- Moves numberOfGroupingMembers from GroupingsService to GroupingOwnerService
- Fixes PascalCase use of SearchString into camelCase (searchString)
- Fixes GroupingsRestControllerv2_1.updateOptAttribute in Swagger to use correct id

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
