### PR TITLE
Groupings-1997, Update Endpoints

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -487,13 +487,12 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get an owner's owned groupings by uid or uhUuid.
      */
-    @GetMapping("/owners/{uhIdentifier:[\\w-:.]+}/groupings")
-    public ResponseEntity<GroupingPaths> ownerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
-                                                             @PathVariable String uhIdentifier) {
+    @GetMapping("/owners/groupings")
+    public ResponseEntity<GroupingPaths> ownerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST ownerGroupings...");
         return ResponseEntity
                 .ok()
-                .body(memberAttributeService.getOwnedGroupings(currentUser, uhIdentifier));
+                .body(memberAttributeService.getOwnedGroupings(currentUser));
     }
 
     /**
@@ -653,50 +652,51 @@ public class GroupingsRestControllerv2_1 {
     /**
      * True if currentUser is an owner.
      */
-    @GetMapping(value = "/members/{uhIdentifier}/is-owner")
+    @GetMapping("/members/is-owner")
     @ResponseBody
-    public ResponseEntity<Boolean> hasOwnerPrivs(@PathVariable String uhIdentifier) {
+    public ResponseEntity<Boolean> hasOwnerPrivs(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST hasOwnerPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isOwner(uhIdentifier));
+                .body(memberService.isOwner(currentUser));
     }
 
     /**
-     * True if user is an owner of the grouping.
+     * True if currentUser is an owner of the grouping.
      */
-    @GetMapping(value = "/members/{path:[\\w-:.]+}/{uhIdentifier}/is-owner")
+    @GetMapping(value = "/members/{path:[\\w-:.]+}/is-owner")
     @ResponseBody
-    public ResponseEntity<Boolean> hasGroupingOwnerPrivs(@PathVariable String path, @PathVariable String uhIdentifier) {
+    public ResponseEntity<Boolean> hasGroupingOwnerPrivs(
+            @PathVariable String path,
+            @RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST hasGroupingOwnerPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isOwner(path, uhIdentifier));
+                .body(memberService.isOwner(path, currentUser));
     }
 
     /**
      * True if currentUser is an admin.
      */
-    @GetMapping(value = "/members/{uhIdentifier}/is-admin")
+    @GetMapping(value = "/members/is-admin")
     @ResponseBody
-    public ResponseEntity<Boolean> hasAdminPrivs(@PathVariable String uhIdentifier) {
+    public ResponseEntity<Boolean> hasAdminPrivs(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST hasAdminPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isAdmin(uhIdentifier));
+                .body(memberService.isAdmin(currentUser));
     }
 
     /**
      * Get the number of groupings that the current user owns
      */
-    @GetMapping(value = "/owners/{uhIdentifier:[\\w-:.]+}/groupings/count")
+    @GetMapping(value = "/owners/groupings/count")
     @ResponseBody
-    public ResponseEntity<Integer> getNumberOfGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
-                                                        @PathVariable String uhIdentifier) {
+    public ResponseEntity<Integer> getNumberOfGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST getNumberOfGroupings...");
         return ResponseEntity
                 .ok()
-                .body(memberAttributeService.numberOfGroupings(currentUser, uhIdentifier));
+                .body(memberAttributeService.numberOfGroupings(currentUser));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -485,7 +485,7 @@ public class GroupingsRestControllerv2_1 {
     }
 
     /**
-     * Get an owner's owned groupings by uid or uhUuid.
+     * Get a current user's owned groupings
      */
     @GetMapping("/owners/groupings")
     public ResponseEntity<GroupingPaths> ownerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser) {

--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -652,39 +652,37 @@ public class GroupingsRestControllerv2_1 {
     /**
      * True if currentUser is an owner.
      */
-    @GetMapping("/members/is-owner")
+    @GetMapping(value = "/members/{uhIdentifier}/is-owner")
     @ResponseBody
-    public ResponseEntity<Boolean> hasOwnerPrivs(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
+    public ResponseEntity<Boolean> hasOwnerPrivs(@PathVariable String uhIdentifier) {
         logger.info("Entered REST hasOwnerPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isOwner(currentUser));
+                .body(memberService.isOwner(uhIdentifier));
     }
 
     /**
-     * True if currentUser is an owner of the grouping.
+     * True if user is an owner of the grouping.
      */
-    @GetMapping(value = "/members/{path:[\\w-:.]+}/is-owner")
+    @GetMapping(value = "/members/{path:[\\w-:.]+}/{uhIdentifier}/is-owner")
     @ResponseBody
-    public ResponseEntity<Boolean> hasGroupingOwnerPrivs(
-            @PathVariable String path,
-            @RequestHeader(CURRENT_USER_KEY) String currentUser) {
+    public ResponseEntity<Boolean> hasGroupingOwnerPrivs(@PathVariable String path, @PathVariable String uhIdentifier) {
         logger.info("Entered REST hasGroupingOwnerPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isOwner(path, currentUser));
+                .body(memberService.isOwner(path, uhIdentifier));
     }
 
     /**
      * True if currentUser is an admin.
      */
-    @GetMapping(value = "/members/is-admin")
+    @GetMapping(value = "/members/{uhIdentifier}/is-admin")
     @ResponseBody
-    public ResponseEntity<Boolean> hasAdminPrivs(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
+    public ResponseEntity<Boolean> hasAdminPrivs(@PathVariable String uhIdentifier) {
         logger.info("Entered REST hasAdminPrivs...");
         return ResponseEntity
                 .ok()
-                .body(memberService.isAdmin(currentUser));
+                .body(memberService.isAdmin(uhIdentifier));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
@@ -232,11 +232,11 @@ public class GrouperApiService implements GrouperService {
     }
 
     /**
-     * Get all groups that a currentUser is listed in.
+     * Get all groups that a uhIdentifier is listed in.
      */
-    public GetGroupsResults getGroupsResults(String currentUser) {
+    public GetGroupsResults getGroupsResults(String uhIdentifier) {
         return exec.execute(new GetGroupsCommand()
-                .addUhIdentifier(currentUser)
+                .addUhIdentifier(uhIdentifier)
                 .query(""));
     }
 

--- a/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
@@ -232,11 +232,11 @@ public class GrouperApiService implements GrouperService {
     }
 
     /**
-     * Get all groups that a UH identifier is listed in.
+     * Get all groups that a currentUser is listed in.
      */
-    public GetGroupsResults getGroupsResults(String uhIdentifier) {
+    public GetGroupsResults getGroupsResults(String currentUser) {
         return exec.execute(new GetGroupsCommand()
-                .addUhIdentifier(uhIdentifier)
+                .addUhIdentifier(currentUser)
                 .query(""));
     }
 

--- a/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
@@ -134,8 +134,8 @@ public class GroupingsService {
     /**
      * A list of group paths, filtered by the predicate, in which the uhIdentifier is listed.
      */
-    public List<String> groupPaths(String currentUser, Predicate<String> predicate) {
-        return allGroupPaths(currentUser).stream().filter(predicate).collect(Collectors.toList());
+    public List<String> groupPaths(String uhIdentifier, Predicate<String> predicate) {
+        return allGroupPaths(uhIdentifier).stream().filter(predicate).collect(Collectors.toList());
     }
 
     /**
@@ -172,10 +172,10 @@ public class GroupingsService {
     }
 
     /**
-     * A list of all group paths, in which the currentUser is listed..
+     * A list of all group paths, in which the uhIdentifier is listed..
      */
-    public List<String> allGroupPaths(String currentUser) {
-        List<Group> groups = grouperService.getGroupsResults(currentUser).getGroups();
+    public List<String> allGroupPaths(String uhIdentifier) {
+        List<Group> groups = grouperService.getGroupsResults(uhIdentifier).getGroups();
         return groups.stream().map(Group::getGroupPath).collect(Collectors.toList());
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingsService.java
@@ -134,8 +134,8 @@ public class GroupingsService {
     /**
      * A list of group paths, filtered by the predicate, in which the uhIdentifier is listed.
      */
-    public List<String> groupPaths(String uhIdentifier, Predicate<String> predicate) {
-        return allGroupPaths(uhIdentifier).stream().filter(predicate).collect(Collectors.toList());
+    public List<String> groupPaths(String currentUser, Predicate<String> predicate) {
+        return allGroupPaths(currentUser).stream().filter(predicate).collect(Collectors.toList());
     }
 
     /**
@@ -172,10 +172,10 @@ public class GroupingsService {
     }
 
     /**
-     * A list of all group paths, in which the uhIdentifier is listed..
+     * A list of all group paths, in which the currentUser is listed..
      */
-    public List<String> allGroupPaths(String uhIdentifier) {
-        List<Group> groups = grouperService.getGroupsResults(uhIdentifier).getGroups();
+    public List<String> allGroupPaths(String currentUser) {
+        List<Group> groups = grouperService.getGroupsResults(currentUser).getGroups();
         return groups.stream().map(Group::getGroupPath).collect(Collectors.toList());
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
@@ -91,9 +91,9 @@ public class MemberAttributeService {
     /**
      * Get a list of GroupPaths the user owns, by uid or uhUuid.
      */
-    public GroupingPaths getOwnedGroupings(String currentUser, String uhIdentifier) {
-        logger.info(String.format("getOwnedGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
-        List<String> pathStrings = groupingsService.groupPaths(uhIdentifier, pathHasOwner());
+    public GroupingPaths getOwnedGroupings(String currentUser) {
+        logger.info(String.format("getOwnedGroupings; currentUser: %s;", currentUser));
+        List<String> pathStrings = groupingsService.groupPaths(currentUser, pathHasOwner());
         List<GroupingPath> groupingPaths = new ArrayList<>();
         for (String path : pathStrings) {
             String parentGroupingPath = parentGroupingPath(path);
@@ -107,13 +107,13 @@ public class MemberAttributeService {
     /**
      * Get the number of groupings a user owns, by uid or uhUuid.
      */
-    public Integer numberOfGroupings(String currentUser, String uhIdentifier) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
-        return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
+    public Integer numberOfGroupings(String currentUser) {
+        logger.debug(String.format("numberOfGroupings; currentUser: %s;", currentUser));
+        return groupingsService.groupPaths(currentUser, pathHasOwner()).size();
     }
 
-    public Integer numberOfGroupings(String currentUser, String uhIdentifier, String groupPath) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
-        return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
+    public Integer numberOfGroupings(String currentUser, String groupPath) {
+        logger.debug(String.format("numberOfGroupings; currentUser: %s;", currentUser));
+        return groupingsService.groupPaths(currentUser, pathHasOwner()).size();
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
@@ -107,13 +107,13 @@ public class MemberAttributeService {
     /**
      * Get the number of groupings a user owns, by uid or uhUuid.
      */
-    public Integer numberOfGroupings(String currentUser) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s;", currentUser));
-        return groupingsService.groupPaths(currentUser, pathHasOwner()).size();
+    public Integer numberOfGroupings(String uhIdentifier) {
+        logger.debug(String.format("numberOfGroupings; uhIdentifier: %s;", uhIdentifier));
+        return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
     }
 
-    public Integer numberOfGroupings(String currentUser, String groupPath) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s;", currentUser));
-        return groupingsService.groupPaths(currentUser, pathHasOwner()).size();
+    public Integer numberOfGroupings(String uhIdentifier, String groupPath) {
+        logger.debug(String.format("numberOfGroupings; uhIdentifier: %s;", uhIdentifier));
+        return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
     }
 }

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -831,35 +831,30 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     public void hasOwnerPrivsTest() throws Exception {
         given(memberService.isOwner(CURRENT_USER)).willReturn(false);
-
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/is-owner")
-                        .header("current_user", CURRENT_USER))
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + CURRENT_USER + "/is-owner"))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(result);
-        verify(memberService, times(1)).isOwner(CURRENT_USER);
+        verify(memberService, times(1))
+                .isOwner(CURRENT_USER);
     }
 
     @Test
     public void hasGroupingOwnerPrivsTest() throws Exception {
         String groupingPath = "grouping-path";
-
         given(memberService.isOwner(groupingPath, CURRENT_USER)).willReturn(false);
-
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + groupingPath + "/is-owner")
-                        .header("current_user", CURRENT_USER))
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + groupingPath + "/" + CURRENT_USER + "/is-owner"))
                 .andExpect(status().isOk())
                 .andReturn();
-
         assertNotNull(result);
-        verify(memberService, times(1)).isOwner(groupingPath, CURRENT_USER);
+        verify(memberService, times(1))
+                .isOwner(groupingPath, CURRENT_USER);
     }
 
     @Test
     public void hasAdminPrivsTest() throws Exception {
         given(memberService.isAdmin(CURRENT_USER)).willReturn(false);
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/is-admin")
-                .header("current_user", CURRENT_USER))
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + CURRENT_USER + "/is-admin"))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(result);
@@ -880,7 +875,7 @@ public class GroupingsRestControllerv2_1Test {
         }
         given(memberAttributeService.numberOfGroupings(owner)).willReturn(10);
 
-        mockMvc.perform(get(API_BASE + "/owners/" + uid + "/groupings/count")
+        mockMvc.perform(get(API_BASE + "/owners/groupings/count")
                         .header(CURRENT_USER, owner))
                 .andExpect(status().isOk());
         verify(memberAttributeService, times(1))

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -669,9 +669,9 @@ public class GroupingsRestControllerv2_1Test {
         GroupingPaths groupingPaths = new GroupingPaths();
         groupingPaths.addGroupingPath(new GroupingPath(path, description));
 
-        given(memberAttributeService.getOwnedGroupings(admin, uid))
+        given(memberAttributeService.getOwnedGroupings(admin))
                 .willReturn(groupingPaths);
-        mockMvc.perform(get(API_BASE + "/owners/grouping/groupings")
+        mockMvc.perform(get(API_BASE + "/owners/groupings")
                         .header(CURRENT_USER, admin)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
                 .andExpect(jsonPath("$.groupingPaths[0].path").value(path))
@@ -679,7 +679,7 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(jsonPath("$.groupingPaths[0].description").value("description"));
 
         verify(memberAttributeService, times(1))
-                .getOwnedGroupings(admin, uid);
+                .getOwnedGroupings(admin);
     }
 
     @Test
@@ -831,30 +831,35 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     public void hasOwnerPrivsTest() throws Exception {
         given(memberService.isOwner(CURRENT_USER)).willReturn(false);
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + CURRENT_USER + "/is-owner"))
+
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/is-owner")
+                        .header("current_user", CURRENT_USER))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(result);
-        verify(memberService, times(1))
-                .isOwner(CURRENT_USER);
+        verify(memberService, times(1)).isOwner(CURRENT_USER);
     }
 
     @Test
     public void hasGroupingOwnerPrivsTest() throws Exception {
         String groupingPath = "grouping-path";
+
         given(memberService.isOwner(groupingPath, CURRENT_USER)).willReturn(false);
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + groupingPath + "/" + CURRENT_USER + "/is-owner"))
+
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + groupingPath + "/is-owner")
+                        .header("current_user", CURRENT_USER))
                 .andExpect(status().isOk())
                 .andReturn();
+
         assertNotNull(result);
-        verify(memberService, times(1))
-                .isOwner(groupingPath, CURRENT_USER);
+        verify(memberService, times(1)).isOwner(groupingPath, CURRENT_USER);
     }
 
     @Test
     public void hasAdminPrivsTest() throws Exception {
         given(memberService.isAdmin(CURRENT_USER)).willReturn(false);
-        MvcResult result = mockMvc.perform(get(API_BASE + "/members/" + CURRENT_USER + "/is-admin"))
+        MvcResult result = mockMvc.perform(get(API_BASE + "/members/is-admin")
+                .header("current_user", CURRENT_USER))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(result);
@@ -873,13 +878,13 @@ public class GroupingsRestControllerv2_1Test {
         for (int i = 0; i < 10; i++) {
             groupingPathList.add(new GroupingPath(path));
         }
-        given(memberAttributeService.numberOfGroupings(owner, uid)).willReturn(10);
+        given(memberAttributeService.numberOfGroupings(owner)).willReturn(10);
 
         mockMvc.perform(get(API_BASE + "/owners/" + uid + "/groupings/count")
                         .header(CURRENT_USER, owner))
                 .andExpect(status().isOk());
         verify(memberAttributeService, times(1))
-                .numberOfGroupings(owner, uid);
+                .numberOfGroupings(owner);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -692,9 +692,8 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasAdminPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/is-admin";
-        MvcResult mvcResult = mockMvc.perform(get(url)
-                        .header(CURRENT_USER, ADMIN))
+        String url = API_BASE_URL + "members/" + ADMIN + "/is-admin";
+        MvcResult mvcResult = mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
@@ -702,9 +701,8 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasOwnerPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/is-owner";
-        MvcResult mvcResult = mockMvc.perform(get(url)
-                        .header(CURRENT_USER, ADMIN))
+        String url = API_BASE_URL + "members/" + ADMIN + "/is-owner";
+        MvcResult mvcResult = mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
@@ -712,9 +710,8 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasGroupingOwnerPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/" + GROUPING + "/is-owner";
-        MvcResult mvcResult = mockMvc.perform(get(url)
-                        .header(CURRENT_USER, ADMIN))
+        String url = API_BASE_URL + "members/" + GROUPING + "/" + ADMIN + "/is-owner";
+        MvcResult mvcResult = mockMvc.perform(get(url))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -606,7 +606,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void ownerGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "owners/" + ADMIN + "/groupings";
+        String url = API_BASE_URL + "owners/groupings";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
@@ -692,8 +692,9 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasAdminPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/" + ADMIN + "/is-admin";
-        MvcResult mvcResult = mockMvc.perform(get(url))
+        String url = API_BASE_URL + "members/is-admin";
+        MvcResult mvcResult = mockMvc.perform(get(url)
+                        .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
@@ -701,8 +702,9 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasOwnerPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/" + ADMIN + "/is-owner";
-        MvcResult mvcResult = mockMvc.perform(get(url))
+        String url = API_BASE_URL + "members/is-owner";
+        MvcResult mvcResult = mockMvc.perform(get(url)
+                        .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
@@ -710,8 +712,9 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void hasGroupingOwnerPrivsTest() throws Exception {
-        String url = API_BASE_URL + "members/" + GROUPING + "/" + ADMIN + "/is-owner";
-        MvcResult mvcResult = mockMvc.perform(get(url))
+        String url = API_BASE_URL + "members/" + GROUPING + "/is-owner";
+        MvcResult mvcResult = mockMvc.perform(get(url)
+                        .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsByteArray(), Boolean.class));
@@ -719,7 +722,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void getNumberOfGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "owners/" + testUids.get(0) + "/groupings/count";
+        String url = API_BASE_URL + "owners/groupings/count";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())

--- a/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
@@ -179,7 +179,7 @@ public class TestMemberAttributeService {
     public void getOwnedGroupingsTest() {
         // Groupings owned by current admin should complement
         // the list of memberships that the current admin is in.
-        GroupingPaths groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, ADMIN);
+        GroupingPaths groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
         ManageSubjectResults manageSubjectResults = membershipService.manageSubjectResults(ADMIN, ADMIN);
         assertNotNull(groupingsOwned);
         groupingsOwned.getGroupingPaths().forEach(groupingPath -> {
@@ -193,13 +193,13 @@ public class TestMemberAttributeService {
         List<String> testList = new ArrayList<>();
         String testUid = testUids.get(0);
         testList.add(testUid);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, testUid);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
         assertFalse(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
 
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, testUid);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
         assertTrue(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
@@ -212,19 +212,19 @@ public class TestMemberAttributeService {
         String testUid = testUids.get(0);
         List<String> testList = new ArrayList<>();
         testList.add(testUid);
-        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(ADMIN, testUid);
+        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(ADMIN);
         assertNotNull(numberOfGroupings);
 
         // Should equal the size of the list returned from getOwnedGroupings().
-        assertEquals(memberAttributeService.getOwnedGroupings(ADMIN, testUid).getGroupingPaths().size(), numberOfGroupings);
+        assertEquals(memberAttributeService.getOwnedGroupings(ADMIN).getGroupingPaths().size(), numberOfGroupings);
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
 
         // Should increase by one if user is added as owner to a grouping.
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(ADMIN, testUid));
+        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(ADMIN));
         updateMemberService.removeOwnerships(ADMIN, GROUPING, testList);
 
         // Should decrease by one if user is added as owner to a grouping.
-        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(ADMIN, testUid));
+        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(ADMIN));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
@@ -193,13 +193,13 @@ public class TestMemberAttributeService {
         List<String> testList = new ArrayList<>();
         String testUid = testUids.get(0);
         testList.add(testUid);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(testUid);
         assertFalse(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
 
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(testUid);
         assertTrue(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
@@ -212,19 +212,19 @@ public class TestMemberAttributeService {
         String testUid = testUids.get(0);
         List<String> testList = new ArrayList<>();
         testList.add(testUid);
-        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(ADMIN);
+        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(testUid);
         assertNotNull(numberOfGroupings);
 
         // Should equal the size of the list returned from getOwnedGroupings().
-        assertEquals(memberAttributeService.getOwnedGroupings(ADMIN).getGroupingPaths().size(), numberOfGroupings);
+        assertEquals(memberAttributeService.getOwnedGroupings(testUid).getGroupingPaths().size(), numberOfGroupings);
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
 
         // Should increase by one if user is added as owner to a grouping.
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(ADMIN));
+        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(testUid));
         updateMemberService.removeOwnerships(ADMIN, GROUPING, testList);
 
         // Should decrease by one if user is added as owner to a grouping.
-        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(ADMIN));
+        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(testUid));
     }
 }


### PR DESCRIPTION
# [Groupings 1997, Update Endpoints](https://uhawaii.atlassian.net/browse/GROUPINGS-1997)

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-1997)

# List of squashed commits

- Commit 1: Changed Controller to use CurrentUser for methods hasOwnerPrivs, hasGroupingOwnerPrivs, and hasAdminPrivs
Updated Tests to expect headers
- Commit 2: Reverted changes for previous commit after more detailed instructions, Updated ownerGrouping endpoint to use currentUser Custom Header instead of UhIdentifier
- Commit 3: Update Endpoints GetNumberOfGrouping and OwnerGroupings to accept CURRENT_USER_KEY only and updated related methods and tests accordingly


# Test Checklist

- [X] Exhibits Clear Code Structure:
- [X] Project Unit Tests Passed:
- [X] Project Integration Tests Passed:
- [X] Executes Expected Functionality:
- [X] Tested For Incorrect/Unexpected Inputs:
