### PR TITLE
Dev zhongyu 2024

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -510,16 +510,16 @@ public class GroupingsRestControllerv2_1 {
     }
 
     /**
-     * Update grouping to add new path owners.
+     * Update grouping to add new owner-groupings.
      */
-    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/owners/path-owner/{pathOwners}")
-    public ResponseEntity<GroupingAddResults> addGroupPathOwners(@RequestHeader(CURRENT_USER_KEY) String currentUser,
+    @PutMapping(value = "/groupings/{path:[\\w-:.]+}/owners/owner-grouping/{ownerGroupings}")
+    public ResponseEntity<GroupingAddResults> addOwnerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
                                                         @PathVariable String path,
-                                                        @PathVariable List<String> pathOwners) {
-        logger.info("Entered REST addGroupPathOwners...");
+                                                        @PathVariable List<String> ownerGroupings) {
+        logger.info("Entered REST addOwnerGroupings...");
         return ResponseEntity
                 .ok()
-                .body(updateMemberService.addGroupPathOwnerships(currentUser, path, pathOwners));
+                .body(updateMemberService.addOwnerGroupingOwnerships(currentUser, path, ownerGroupings));
     }
 
 
@@ -538,16 +538,16 @@ public class GroupingsRestControllerv2_1 {
 
 
     /**
-     * Delete grouping group path owners.
+     * Delete grouping owner-groupings.
      */
-    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/owners/path-owner/{pathOwners}")
-    public ResponseEntity<GroupingRemoveResults> removeGroupPathOwners(@RequestHeader(CURRENT_USER_KEY) String currentUser,
+    @DeleteMapping(value = "/groupings/{path:[\\w-:.]+}/owners/owner-grouping/{ownerGroupings}")
+    public ResponseEntity<GroupingRemoveResults> removeOwnerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
                                                               @PathVariable String path,
-                                                              @PathVariable List<String> pathOwners) {
-        logger.info("Entered REST removeGroupPathOwners");
+                                                              @PathVariable List<String> ownerGroupings) {
+        logger.info("Entered REST removeOwnerGroupings");
         return ResponseEntity
                 .ok()
-                .body(updateMemberService.removeGroupPathOwnerships(currentUser, path, pathOwners));
+                .body(updateMemberService.removeOwnerGroupingOwnerships(currentUser, path, ownerGroupings));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -485,15 +485,14 @@ public class GroupingsRestControllerv2_1 {
     }
 
     /**
-     * Get an owner's owned groupings by uid or uhUuid.
+     * Get a current user's owned groupings
      */
-    @GetMapping("/owners/{uhIdentifier:[\\w-:.]+}/groupings")
-    public ResponseEntity<GroupingPaths> ownerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
-                                                             @PathVariable String uhIdentifier) {
+    @GetMapping("/owners/groupings")
+    public ResponseEntity<GroupingPaths> ownerGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST ownerGroupings...");
         return ResponseEntity
                 .ok()
-                .body(memberAttributeService.getOwnedGroupings(currentUser, uhIdentifier));
+                .body(memberAttributeService.getOwnedGroupings(currentUser));
     }
 
     /**
@@ -689,14 +688,13 @@ public class GroupingsRestControllerv2_1 {
     /**
      * Get the number of groupings that the current user owns
      */
-    @GetMapping(value = "/owners/{uhIdentifier:[\\w-:.]+}/groupings/count")
+    @GetMapping(value = "/owners/groupings/count")
     @ResponseBody
-    public ResponseEntity<Integer> getNumberOfGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser,
-                                                        @PathVariable String uhIdentifier) {
+    public ResponseEntity<Integer> getNumberOfGroupings(@RequestHeader(CURRENT_USER_KEY) String currentUser) {
         logger.info("Entered REST getNumberOfGroupings...");
         return ResponseEntity
                 .ok()
-                .body(memberAttributeService.numberOfGroupings(currentUser, uhIdentifier));
+                .body(memberAttributeService.numberOfGroupings(currentUser));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
@@ -232,7 +232,7 @@ public class GrouperApiService implements GrouperService {
     }
 
     /**
-     * Get all groups that a UH identifier is listed in.
+     * Get all groups that a uhIdentifier is listed in.
      */
     public GetGroupsResults getGroupsResults(String uhIdentifier) {
         return exec.execute(new GetGroupsCommand()

--- a/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperApiService.java
@@ -318,13 +318,13 @@ public class GrouperApiService implements GrouperService {
     }
 
     /**
-     * Add multiple path owners to a group owner listing.
+     * Add multiple owner-groupings to a group owner listing.
      */
-    public AddMembersResults addGroupPathOwners(String currentUser, String groupPath, List<String> groupPathOwners) {
+    public AddMembersResults addOwnerGroupings(String currentUser, String groupPath, List<String> ownerGroupings) {
         return exec.execute(new AddMembersCommand()
                 .owner(currentUser)
                 .assignGroupPath(groupPath)
-                .addGroupPathOwners(groupPathOwners));
+                .addOwnerGroupings(ownerGroupings));
     }
 
     /**
@@ -348,14 +348,14 @@ public class GrouperApiService implements GrouperService {
     }
 
     /**
-     * Remove multiple path owners from a group owner listing.
+     * Remove multiple owner-groupings from a group owner listing.
      */
-    public RemoveMembersResults removeGroupPathOwners(String currentUser, String groupPath,
-            List<String> groupPathOwners) {
+    public RemoveMembersResults removeOwnerGroupings(String currentUser, String groupPath,
+            List<String> ownerGroupings) {
         return exec.execute(new RemoveMembersCommand()
                 .owner(currentUser)
                 .assignGroupPath(groupPath)
-                .addGroupPathOwners(groupPathOwners));
+                .addOwnerGroupings(ownerGroupings));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/GrouperService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GrouperService.java
@@ -75,13 +75,13 @@ public interface GrouperService {
 
     AddMembersResults addMembers(String currentUser, String groupPath, List<String> uhIdentifiers);
 
-    AddMembersResults addGroupPathOwners(String currentUser, String groupPath, List<String> groupPathOwners);
+    AddMembersResults addOwnerGroupings(String currentUser, String groupPath, List<String> ownerGroupings);
 
     RemoveMemberResult removeMember(String currentUser, String groupPath, String uhIdentifier);
 
     RemoveMembersResults removeMembers(String currentUser, String groupPath, List<String> uhIdentifiers);
 
-    RemoveMembersResults removeGroupPathOwners(String currentUser, String groupPath, List<String> groupPathOwners);
+    RemoveMembersResults removeOwnerGroupings(String currentUser, String groupPath, List<String> ownerGroupings);
 
     AddMembersResults resetGroupMembers(String groupPath);
 

--- a/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
+++ b/src/main/java/edu/hawaii/its/api/service/MemberAttributeService.java
@@ -91,9 +91,9 @@ public class MemberAttributeService {
     /**
      * Get a list of GroupPaths the user owns, by uid or uhUuid.
      */
-    public GroupingPaths getOwnedGroupings(String currentUser, String uhIdentifier) {
-        logger.info(String.format("getOwnedGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
-        List<String> pathStrings = groupingsService.groupPaths(uhIdentifier, pathHasOwner());
+    public GroupingPaths getOwnedGroupings(String currentUser) {
+        logger.info(String.format("getOwnedGroupings; currentUser: %s;", currentUser));
+        List<String> pathStrings = groupingsService.groupPaths(currentUser, pathHasOwner());
         List<GroupingPath> groupingPaths = new ArrayList<>();
         for (String path : pathStrings) {
             String parentGroupingPath = parentGroupingPath(path);
@@ -107,13 +107,13 @@ public class MemberAttributeService {
     /**
      * Get the number of groupings a user owns, by uid or uhUuid.
      */
-    public Integer numberOfGroupings(String currentUser, String uhIdentifier) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
+    public Integer numberOfGroupings(String uhIdentifier) {
+        logger.debug(String.format("numberOfGroupings; uhIdentifier: %s;", uhIdentifier));
         return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
     }
 
-    public Integer numberOfGroupings(String currentUser, String uhIdentifier, String groupPath) {
-        logger.debug(String.format("numberOfGroupings; currentUser: %s; uhIdentifier: %s;", currentUser, uhIdentifier));
+    public Integer numberOfGroupings(String uhIdentifier, String groupPath) {
+        logger.debug(String.format("numberOfGroupings; uhIdentifier: %s;", uhIdentifier));
         return groupingsService.groupPaths(uhIdentifier, pathHasOwner()).size();
     }
 }

--- a/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
+++ b/src/main/java/edu/hawaii/its/api/service/OotbGrouperApiService.java
@@ -229,10 +229,10 @@ public class OotbGrouperApiService implements GrouperService {
     }
 
     /**
-     * Add multiple path owners to a group owner listing.
+     * Add multiple owner-groupings to a group owner listing.
      */
-    public AddMembersResults addGroupPathOwners(String currentUser, String groupPath, List<String> groupPathOwners) {
-        return ootbGroupingPropertiesService.addMembers(currentUser, groupPath, groupPathOwners);
+    public AddMembersResults addOwnerGroupings(String currentUser, String groupPath, List<String> ownerGroupings) {
+        return ootbGroupingPropertiesService.addMembers(currentUser, groupPath, ownerGroupings);
     }
 
     /**
@@ -250,12 +250,12 @@ public class OotbGrouperApiService implements GrouperService {
     }
 
     /**
-     * Remove multiple path owners from a group owner listing.
+     * Remove multiple owner-groupings from a group owner listing.
      */
 
-    public RemoveMembersResults removeGroupPathOwners(String currentUser, String groupPath,
-            List<String> groupPathOwners) {
-        return ootbGroupingPropertiesService.removeMembers(currentUser, groupPath, groupPathOwners);
+    public RemoveMembersResults removeOwnerGroupings(String currentUser, String groupPath,
+            List<String> ownerGroupings) {
+        return ootbGroupingPropertiesService.removeMembers(currentUser, groupPath, ownerGroupings);
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
+++ b/src/main/java/edu/hawaii/its/api/service/UpdateMemberService.java
@@ -108,21 +108,21 @@ public class UpdateMemberService {
         return addOwner(currentUser, groupingPath, validIdentifier);
     }
 
-    public GroupingAddResults addGroupPathOwnerships(String currentUser, String groupingPath,
-            List<String> groupPathOwners) {
-        // TODO: should we also check if groupPathOwners are valid paths?
+    public GroupingAddResults addOwnerGroupingOwnerships(String currentUser, String groupingPath,
+            List<String> ownerGroupings) {
+        // TODO: should we also check if OwnerGroupings are valid paths?
         groupPathService.checkPath(groupingPath);
         checkIfOwnerOrAdminUser(currentUser, groupingPath);
 
         // Check that owner limit will not be exceeded after addition.
         Integer ownerCount = groupingAssignmentService.numberOfAllOwners(currentUser, groupingPath);
-        for (String path: groupPathOwners) {
+        for (String path: ownerGroupings) {
             ownerCount += groupingOwnerService.numberOfGroupingMembers(currentUser, path);
         }
         if (ownerCount > OWNERS_LIMIT) {
             throw new OwnerLimitExceededException();
         }
-        return addGroupPathOwners(currentUser, groupingPath, groupPathOwners);
+        return addOwnerGroupings(currentUser, groupingPath, ownerGroupings);
     }
 
     public GroupingRemoveResults removeOwnerships(String currentUser, String groupingPath,
@@ -146,13 +146,13 @@ public class UpdateMemberService {
         return removeOwner(currentUser, groupingPath, validIdentifier);
     }
 
-    public GroupingRemoveResults removeGroupPathOwnerships(String currentUser, String groupingPath,
-            List<String> groupPathOwners) {
+    public GroupingRemoveResults removeOwnerGroupingOwnerships(String currentUser, String groupingPath,
+            List<String> ownerGroupings) {
         log.info(String.format("removeGroupPathOwnerships; currentUser: %s; groupingPath: %s; uhIdentifiers: %s;",
-                currentUser, groupingPath, groupPathOwners));
+                currentUser, groupingPath, ownerGroupings));
         groupPathService.checkPath(groupingPath);
         checkIfOwnerOrAdminUser(currentUser, groupingPath);
-        return removeGroupPathOwners(currentUser, groupingPath, groupPathOwners);
+        return removeOwnerGroupings(currentUser, groupingPath, ownerGroupings);
     }
 
     public GroupingMoveMembersResult addIncludeMembers(String currentUser, String groupingPath,
@@ -456,11 +456,11 @@ public class UpdateMemberService {
         return result;
     }
 
-    private GroupingAddResults addGroupPathOwners(String currentUser, String groupingPath,
-            List<String> groupPathOwners) {
+    private GroupingAddResults addOwnerGroupings(String currentUser, String groupingPath,
+            List<String> ownerGroupings) {
         AddMembersResults addMembersResults =
-                grouperService.addGroupPathOwners(currentUser, groupingPath + GroupType.OWNERS.value(),
-                        groupPathOwners);
+                grouperService.addOwnerGroupings(currentUser, groupingPath + GroupType.OWNERS.value(),
+                        ownerGroupings);
         GroupingAddResults results = new GroupingAddResults(addMembersResults);
         if (grouperService instanceof GrouperApiService) {
             timestampService.update(results);
@@ -488,11 +488,11 @@ public class UpdateMemberService {
         return result;
     }
 
-    private GroupingRemoveResults removeGroupPathOwners(String currentUser, String groupingPath,
-            List<String> groupPathOwners) {
+    private GroupingRemoveResults removeOwnerGroupings(String currentUser, String groupingPath,
+            List<String> ownerGroupings) {
         RemoveMembersResults removeMembersResults =
-                grouperService.removeGroupPathOwners(currentUser, groupingPath + GroupType.OWNERS.value(),
-                        groupPathOwners);
+                grouperService.removeOwnerGroupings(currentUser, groupingPath + GroupType.OWNERS.value(),
+                        ownerGroupings);
         GroupingRemoveResults results = new GroupingRemoveResults(removeMembersResults);
         if (grouperService instanceof GrouperApiService) {
             timestampService.update(results);

--- a/src/main/java/edu/hawaii/its/api/wrapper/AddMembersCommand.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/AddMembersCommand.java
@@ -68,18 +68,18 @@ public class AddMembersCommand extends GrouperCommand<AddMembersCommand> impleme
         return this;
     }
 
-    public AddMembersCommand addGroupPathOwner(String groupPath) {
+    public AddMembersCommand addOwnerGrouping(String groupPath) {
         WsSubjectLookup wsSubjectLookup = new WsSubjectLookup();
-        // we can check added member is path owner when sourceId is g:gsa. That means it's a group
+        // we can check added member is owner-groupings when sourceId is g:gsa. That means it's a group
         wsSubjectLookup.setSubjectSourceId("g:gsa");
         wsSubjectLookup.setSubjectIdentifier(groupPath);
         gcAddMember.addSubjectLookup(wsSubjectLookup);
         return this;
     }
 
-    public AddMembersCommand addGroupPathOwners(List<String> groupPaths) {
+    public AddMembersCommand addOwnerGroupings(List<String> groupPaths) {
         for(String groupPath: groupPaths){
-            addGroupPathOwner(groupPath);
+            addOwnerGrouping(groupPath);
         }
         return this;
     }

--- a/src/main/java/edu/hawaii/its/api/wrapper/RemoveMembersCommand.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/RemoveMembersCommand.java
@@ -54,7 +54,7 @@ public class RemoveMembersCommand extends GrouperCommand<RemoveMembersCommand> i
         return this;
     }
 
-    public RemoveMembersCommand addGroupPathOwner(String groupPath) {
+    public RemoveMembersCommand addOwnerGrouping(String groupPath) {
         WsSubjectLookup wsSubjectLookup = new WsSubjectLookup();
         // we can check added member is a path owners when sourceId is g:gsa. That means it's a group
         wsSubjectLookup.setSubjectSourceId("g:gsa");
@@ -63,9 +63,9 @@ public class RemoveMembersCommand extends GrouperCommand<RemoveMembersCommand> i
         return this;
     }
 
-    public RemoveMembersCommand addGroupPathOwners(List<String> groupPaths) {
+    public RemoveMembersCommand addOwnerGroupings(List<String> groupPaths) {
         for(String groupPath: groupPaths){
-            addGroupPathOwner(groupPath);
+            addOwnerGrouping(groupPath);
         }
         return this;
     }

--- a/src/main/resources/application-integrationTest.properties
+++ b/src/main/resources/application-integrationTest.properties
@@ -5,6 +5,7 @@ spring.config.import=optional:file:${user.home}/.${user.name}-conf/uh-groupings-
 
 # =========================================================================
 # Test.
+groupings.api.test.owner_grouping=tmp:${groupings.api.localhost.user}:${groupings.api.localhost.user}-complex
 groupings.api.test.grouping_large=tmp:${groupings.api.localhost.user}:${groupings.api.localhost.user}-large
 groupings.api.test.grouping_large_basis=${groupings.api.test.grouping_large}${groupings.api.basis}
 groupings.api.test.grouping_large_include=${groupings.api.test.grouping_large}${groupings.api.include}

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -705,24 +705,24 @@ public class GroupingsRestControllerv2_1Test {
     }
 
     @Test
-    public void addGroupPathOwnersTest() throws Exception {
-        List<String> pathOwnersToAdd = new ArrayList<>();
+    public void addOwnerGroupingsTest() throws Exception {
+        List<String> ownerGroupingsToAdd = new ArrayList<>();
         GroupingAddResults groupingAddResults = new GroupingAddResults();
-        pathOwnersToAdd.add("tmp:tst04name:groupPath04");
-        pathOwnersToAdd.add("tmp:tst05name:groupPath05");
-        pathOwnersToAdd.add("tmp:tst06name:groupPath06");
+        ownerGroupingsToAdd.add("tmp:tst04name:groupPath04");
+        ownerGroupingsToAdd.add("tmp:tst05name:groupPath05");
+        ownerGroupingsToAdd.add("tmp:tst06name:groupPath06");
 
-        given(updateMemberService.addGroupPathOwnerships(UID, "grouping", pathOwnersToAdd))
+        given(updateMemberService.addOwnerGroupingOwnerships(UID, "grouping", ownerGroupingsToAdd))
                 .willReturn(groupingAddResults);
 
-        MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/path-owner/" + String.join(",", pathOwnersToAdd))
+        MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/owner-grouping/" + String.join(",", ownerGroupingsToAdd))
                         .header(CURRENT_USER, UID))
                 .andExpect(status().isOk())
                 .andReturn();
 
         assertThat(result, notNullValue());
         verify(updateMemberService, times(1))
-                .addGroupPathOwnerships(UID, "grouping", pathOwnersToAdd);
+                .addOwnerGroupingOwnerships(UID, "grouping", ownerGroupingsToAdd);
     }
 
     @Test
@@ -747,24 +747,24 @@ public class GroupingsRestControllerv2_1Test {
     }
 
     @Test
-    public void removeGroupPathOwnersTest() throws Exception {
-        List<String> pathOwnersToAdd = new ArrayList<>();
+    public void removeOwnerGroupingsTest() throws Exception {
+        List<String> ownerGroupingsToAdd = new ArrayList<>();
         GroupingRemoveResults groupingRemoveResults = new GroupingRemoveResults();
-        pathOwnersToAdd.add("tmp:tst04name:groupPath04");
-        pathOwnersToAdd.add("tmp:tst05name:groupPath05");
-        pathOwnersToAdd.add("tmp:tst06name:groupPath06");
+        ownerGroupingsToAdd.add("tmp:tst04name:groupPath04");
+        ownerGroupingsToAdd.add("tmp:tst05name:groupPath05");
+        ownerGroupingsToAdd.add("tmp:tst06name:groupPath06");
 
-        given(updateMemberService.removeOwnerships(UID, "grouping", pathOwnersToAdd))
+        given(updateMemberService.removeOwnerships(UID, "grouping", ownerGroupingsToAdd))
                 .willReturn(groupingRemoveResults);
 
         MvcResult result =
-                mockMvc.perform(delete(API_BASE + "/groupings/grouping/owners/path-owner/" + String.join(",", pathOwnersToAdd))
+                mockMvc.perform(delete(API_BASE + "/groupings/grouping/owners/owner-grouping/" + String.join(",", ownerGroupingsToAdd))
                                 .header(CURRENT_USER, UID))
                         .andExpect(status().isOk())
                         .andReturn();
         assertNotNull(result);
         verify(updateMemberService, times(1))
-                .removeGroupPathOwnerships(UID, "grouping", pathOwnersToAdd);
+                .removeOwnerGroupingOwnerships(UID, "grouping", ownerGroupingsToAdd);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -669,9 +669,9 @@ public class GroupingsRestControllerv2_1Test {
         GroupingPaths groupingPaths = new GroupingPaths();
         groupingPaths.addGroupingPath(new GroupingPath(path, description));
 
-        given(memberAttributeService.getOwnedGroupings(admin, uid))
+        given(memberAttributeService.getOwnedGroupings(admin))
                 .willReturn(groupingPaths);
-        mockMvc.perform(get(API_BASE + "/owners/grouping/groupings")
+        mockMvc.perform(get(API_BASE + "/owners/groupings")
                         .header(CURRENT_USER, admin)).andExpect(status().isOk())
                 .andExpect(jsonPath("$.resultCode").value("SUCCESS"))
                 .andExpect(jsonPath("$.groupingPaths[0].path").value(path))
@@ -679,7 +679,7 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(jsonPath("$.groupingPaths[0].description").value("description"));
 
         verify(memberAttributeService, times(1))
-                .getOwnedGroupings(admin, uid);
+                .getOwnedGroupings(admin);
     }
 
     @Test
@@ -873,13 +873,13 @@ public class GroupingsRestControllerv2_1Test {
         for (int i = 0; i < 10; i++) {
             groupingPathList.add(new GroupingPath(path));
         }
-        given(memberAttributeService.numberOfGroupings(owner, uid)).willReturn(10);
+        given(memberAttributeService.numberOfGroupings(owner)).willReturn(10);
 
-        mockMvc.perform(get(API_BASE + "/owners/" + uid + "/groupings/count")
+        mockMvc.perform(get(API_BASE + "/owners/groupings/count")
                         .header(CURRENT_USER, owner))
                 .andExpect(status().isOk());
         verify(memberAttributeService, times(1))
-                .numberOfGroupings(owner, uid);
+                .numberOfGroupings(owner);
     }
 
     @Test

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -606,7 +606,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void ownerGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "owners/" + ADMIN + "/groupings";
+        String url = API_BASE_URL + "owners/groupings";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())
@@ -719,7 +719,7 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     public void getNumberOfGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "owners/" + testUids.get(0) + "/groupings/count";
+        String url = API_BASE_URL + "owners/groupings/count";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         .header(CURRENT_USER, ADMIN))
                 .andExpect(status().isOk())

--- a/src/test/java/edu/hawaii/its/api/service/TestGrouperApiService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGrouperApiService.java
@@ -299,26 +299,26 @@ public class TestGrouperApiService {
 
     @Test
     public void getImmediateMembers() {
-        grouperService.addGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
+        grouperService.addOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
         GetMembersResult immediateMembers = grouperService.getImmediateMembers(ADMIN, GROUPING_OWNERS);
         assertNotNull(immediateMembers);
         assertEquals("SUCCESS", immediateMembers.getResultCode());
         SubjectsResults subjectsResults = grouperService.getSubjects(GROUPING_OWNERS, GROUPING_SINGLE);
         assertNotNull(subjectsResults);
         assertEquals("SUCCESS", subjectsResults.getResultCode());
-        grouperService.removeGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
+        grouperService.removeOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
     }
 
     @Test
     public void getAllMembers() {
-        grouperService.addGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
+        grouperService.addOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
         GetMembersResult allMembers = grouperService.getAllMembers(ADMIN, GROUPING_OWNERS);
         assertNotNull(allMembers);
         assertEquals("SUCCESS", allMembers.getResultCode());
         SubjectsResults subjectsResults = grouperService.getSubjects(GROUPING_OWNERS, GROUPING_SINGLE);
         assertNotNull(subjectsResults);
         assertEquals("SUCCESS", subjectsResults.getResultCode());
-        grouperService.removeGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
+        grouperService.removeOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING_SINGLE));
     }
 
     @Test
@@ -516,19 +516,19 @@ public class TestGrouperApiService {
     @Test
     public void addRemovePathOwners() {
         // With Group Path.
-        AddMembersResults addMembersResults = grouperService.addGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING));
+        AddMembersResults addMembersResults = grouperService.addOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING));
         assertNotNull(addMembersResults);
         assertEquals("SUCCESS", addMembersResults.getResultCode());
 
-        RemoveMembersResults removeMembersResults = grouperService.removeGroupPathOwners(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING));
+        RemoveMembersResults removeMembersResults = grouperService.removeOwnerGroupings(ADMIN, GROUPING_OWNERS, Collections.singletonList(GROUPING));
         assertNotNull(removeMembersResults);
         assertEquals("SUCCESS", removeMembersResults.getResultCode());
 
-        // Add and Remove duplicated group path owners
-        addMembersResults = grouperService.addGroupPathOwners(ADMIN, GROUPING_OWNERS, Arrays.asList(GROUPING, GROUPING));
+        // Add and Remove duplicated owner-groupings
+        addMembersResults = grouperService.addOwnerGroupings(ADMIN, GROUPING_OWNERS, Arrays.asList(GROUPING, GROUPING));
         assertNotNull(addMembersResults);
         assertEquals("SUCCESS_ALREADY_EXISTED", addMembersResults.getResults().get(addMembersResults.getResults().size()-1).getResultCode());
-        removeMembersResults = grouperService.removeGroupPathOwners(ADMIN, GROUPING_OWNERS, Arrays.asList(GROUPING, GROUPING));
+        removeMembersResults = grouperService.removeOwnerGroupings(ADMIN, GROUPING_OWNERS, Arrays.asList(GROUPING, GROUPING));
         assertNotNull(removeMembersResults);
         assertEquals("SUCCESS_WASNT_IMMEDIATE", removeMembersResults.getResults().get(removeMembersResults.getResults().size()-1).getResultCode());
     }

--- a/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestMemberAttributeService.java
@@ -179,7 +179,7 @@ public class TestMemberAttributeService {
     public void getOwnedGroupingsTest() {
         // Groupings owned by current admin should complement
         // the list of memberships that the current admin is in.
-        GroupingPaths groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, ADMIN);
+        GroupingPaths groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN);
         ManageSubjectResults manageSubjectResults = membershipService.manageSubjectResults(ADMIN, ADMIN);
         assertNotNull(groupingsOwned);
         groupingsOwned.getGroupingPaths().forEach(groupingPath -> {
@@ -193,13 +193,13 @@ public class TestMemberAttributeService {
         List<String> testList = new ArrayList<>();
         String testUid = testUids.get(0);
         testList.add(testUid);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, testUid);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(testUid);
         assertFalse(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
 
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        groupingsOwned = memberAttributeService.getOwnedGroupings(ADMIN, testUid);
+        groupingsOwned = memberAttributeService.getOwnedGroupings(testUid);
         assertTrue(
                 groupingsOwned.getGroupingPaths().stream()
                         .anyMatch(groupingPath -> groupingPath.getPath().equals(GROUPING)));
@@ -212,19 +212,19 @@ public class TestMemberAttributeService {
         String testUid = testUids.get(0);
         List<String> testList = new ArrayList<>();
         testList.add(testUid);
-        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(ADMIN, testUid);
+        Integer numberOfGroupings = memberAttributeService.numberOfGroupings(testUid);
         assertNotNull(numberOfGroupings);
 
         // Should equal the size of the list returned from getOwnedGroupings().
-        assertEquals(memberAttributeService.getOwnedGroupings(ADMIN, testUid).getGroupingPaths().size(), numberOfGroupings);
+        assertEquals(memberAttributeService.getOwnedGroupings(testUid).getGroupingPaths().size(), numberOfGroupings);
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
 
         // Should increase by one if user is added as owner to a grouping.
         updateMemberService.addOwnerships(ADMIN, GROUPING, testList);
-        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(ADMIN, testUid));
+        assertEquals(numberOfGroupings + 1, memberAttributeService.numberOfGroupings(testUid));
         updateMemberService.removeOwnerships(ADMIN, GROUPING, testList);
 
         // Should decrease by one if user is added as owner to a grouping.
-        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(ADMIN, testUid));
+        assertEquals(numberOfGroupings, memberAttributeService.numberOfGroupings(testUid));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/UpdateMemberServiceTest.java
@@ -135,7 +135,7 @@ public class UpdateMemberServiceTest {
         assertNotNull(updateMemberService.addOwnerships(TEST_UIDS.get(0), groupPath, TEST_UIDS));
     }
 
-    // TODO: missing test for addGroupPathOwnerships()
+    // TODO: missing test for addOwnerGroupingOwnerships()
 
     @Test
     public void addOwnershipTest() {

--- a/src/test/java/edu/hawaii/its/api/wrapper/AddMembersCommandTest.java
+++ b/src/test/java/edu/hawaii/its/api/wrapper/AddMembersCommandTest.java
@@ -25,8 +25,8 @@ public class AddMembersCommandTest {
         assertNotNull(addMembersCommand.addUhIdentifier(""));
         assertNotNull(addMembersCommand.addUhIdentifier("11111111"));
         assertNotNull(addMembersCommand.assignGroupPath(""));
-        assertNotNull(addMembersCommand.addGroupPathOwner("test-group-path"));
-        assertNotNull(addMembersCommand.addGroupPathOwners(strings));
+        assertNotNull(addMembersCommand.addOwnerGrouping("test-group-path"));
+        assertNotNull(addMembersCommand.addOwnerGroupings(strings));
         assertNotNull(addMembersCommand.owner(""));
         assertNotNull(addMembersCommand.includeUhMemberDetails(true));
         assertNotNull(addMembersCommand.replaceGroupMembers(true));


### PR DESCRIPTION
# [Update naming to stay consistent with project's terminology](https://uhawaii.atlassian.net/browse/GROUPINGS-2024)

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-2024)

# List of squashed commits

- Commit 1: Renamed add/remove GroupPathOwners and all related methods to use Owner-Grouping terminology instead
- Commit 2: Fetched updates from main

# Test Checklist

- [X] Exhibits Clear Code Structure:
- [X] Project Unit Tests Passed:
- [X] Project Jasmine Tests Passed:
- [X] Executes Expected Functionality:
- [X] Tested For Incorrect/Unexpected Inputs:
