### PR TITLE
Add getMembersExistInInclude, getMembersExistInExclude, and getMembersExistInOwners endpoints

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -26,12 +26,12 @@ import edu.hawaii.its.api.groupings.GroupingAddResult;
 import edu.hawaii.its.api.groupings.GroupingAddResults;
 import edu.hawaii.its.api.groupings.GroupingDescription;
 import edu.hawaii.its.api.groupings.GroupingGroupMembers;
-import edu.hawaii.its.api.groupings.GroupingOwnerMembers;
 import edu.hawaii.its.api.groupings.GroupingGroupsMembers;
 import edu.hawaii.its.api.groupings.GroupingMembers;
 import edu.hawaii.its.api.groupings.GroupingMoveMemberResult;
 import edu.hawaii.its.api.groupings.GroupingMoveMembersResult;
 import edu.hawaii.its.api.groupings.GroupingOptAttributes;
+import edu.hawaii.its.api.groupings.GroupingOwnerMembers;
 import edu.hawaii.its.api.groupings.GroupingPaths;
 import edu.hawaii.its.api.groupings.GroupingRemoveResult;
 import edu.hawaii.its.api.groupings.GroupingRemoveResults;
@@ -331,6 +331,49 @@ public class GroupingsRestControllerv2_1 {
         return ResponseEntity
                 .ok()
                 .body(groupingOwnerService.getGroupingMembersIsBasis(currentUser, groupingPath, uhIdentifiers));
+    }
+    
+    /**
+     * Check if the user inputs for modifying exist in the include list of a grouping
+     */
+    @PostMapping(value = "/groupings/{groupingPath}/include-members/in-list")
+    @ResponseBody
+    public ResponseEntity<GroupingMembers> getMembersExistInInclude(
+            @PathVariable String groupingPath,
+            @RequestBody List<String> uhIdentifiers) {
+        logger.info("Entered REST getMembersExistInInclude...");
+	    String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ResponseEntity
+                .ok()
+                .body(groupingOwnerService.getMembersExistInInclude(currentUser, groupingPath, uhIdentifiers));
+    }
+
+    /**
+     * Check if the user inputs for modifying exist in the exclude list of a grouping.
+     */
+    @PostMapping(value = "/groupings/{groupingPath}/exclude-members/in-list")
+    @ResponseBody
+    public ResponseEntity<GroupingMembers> getMembersExistInExclude(@PathVariable String groupingPath,
+            @RequestBody List<String> uhIdentifiers) {
+        logger.info("Entered REST getMembersExistInExclude...");
+	    String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ResponseEntity
+                .ok()
+                .body(groupingOwnerService.getMembersExistInExclude(currentUser, groupingPath, uhIdentifiers));
+    }
+
+    /**
+     * Check if the user inputs for modifying exist in the owners list of a grouping.
+     */
+    @PostMapping(value = "/groupings/{groupingPath}/owners/in-list")
+    @ResponseBody
+    public ResponseEntity<GroupingMembers> getMembersExistInOwners(@PathVariable String groupingPath,
+            @RequestBody List<String> uhIdentifiers) {
+        logger.info("Entered REST getMembersExistInOwners...");
+	    String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
+        return ResponseEntity
+                .ok()
+                .body(groupingOwnerService.getMembersExistInOwners(currentUser, groupingPath, uhIdentifiers));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -334,7 +334,7 @@ public class GroupingsRestControllerv2_1 {
     }
     
     /**
-     * Check if the user inputs for modifying exist in the include list of a grouping
+     * Check which of the given uhIdentifiers are already members of a grouping's include group.
      */
     @PostMapping(value = "/groupings/{groupingPath}/include-members/in-list")
     @ResponseBody
@@ -349,7 +349,7 @@ public class GroupingsRestControllerv2_1 {
     }
 
     /**
-     * Check if the user inputs for modifying exist in the exclude list of a grouping.
+     * Check which of the given uhIdentifiers are already members of a grouping's exclude group.
      */
     @PostMapping(value = "/groupings/{groupingPath}/exclude-members/in-list")
     @ResponseBody
@@ -363,7 +363,7 @@ public class GroupingsRestControllerv2_1 {
     }
 
     /**
-     * Check if the user inputs for modifying exist in the owners list of a grouping.
+     * Check which of the given uhIdentifiers are already owners of a grouping.
      */
     @PostMapping(value = "/groupings/{groupingPath}/owners/in-list")
     @ResponseBody

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingMember.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingMember.java
@@ -52,7 +52,15 @@ public class GroupingMember {
         this.uid = "";
         this.whereListed = "";
     }
-
+    
+    public GroupingMember(HasMemberResult result) {
+        this.name = result.getName();
+        this.firstName = result.getFirstName();
+        this.lastName = result.getLastName();
+        this.uhUuid = result.getUhUuid();
+        this.uid = result.getUid();
+        this.whereListed = "";
+    }
     public String getName() {
         return name;
     }

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingMembers.java
@@ -1,11 +1,11 @@
 package edu.hawaii.its.api.groupings;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 import edu.hawaii.its.api.wrapper.HasMemberResult;
 import edu.hawaii.its.api.wrapper.HasMembersResults;
@@ -32,7 +32,14 @@ public class GroupingMembers {
     public GroupingMembers(HasMembersResults hasMembersResults1, HasMembersResults hasMembersResults2) {
         setMembers(hasMembersResults1, hasMembersResults2);
     }
-
+    
+    public static GroupingMembers fromFilteredResults(List<HasMemberResult> filteredResults) {
+        GroupingMembers groupingMembers = new GroupingMembers();
+        for (HasMemberResult result : filteredResults) {
+            groupingMembers.members.add(new GroupingMember(result));
+        }
+        return groupingMembers;
+    }
     public List<GroupingMember> getMembers() {
         return members;
     }
@@ -60,4 +67,5 @@ public class GroupingMembers {
                     hasMembersResults2.getResults().get(i), hasMembersResults2.getGroup().getExtension()));
         }
     }
+    
 }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -27,6 +27,7 @@ import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.GetMembersResults;
 import edu.hawaii.its.api.wrapper.Group;
 import edu.hawaii.its.api.wrapper.GroupAttributeResults;
+import edu.hawaii.its.api.wrapper.HasMemberResult;
 import edu.hawaii.its.api.wrapper.HasMembersResults;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
 
@@ -134,7 +135,44 @@ public class GroupingOwnerService {
                 groupingPath + GroupType.BASIS.value(), uhIdentifiers);
         return new GroupingMembers(hasMembersResults);
     }
-
+    
+    public GroupingMembers getMembersExistInInclude(String currentUser, String groupingPath,
+            List<String> uhIdentifiers) {
+        HasMembersResults hasMembersResults = grouperService.hasMembersResults(
+                currentUser,
+                groupingPath + GroupType.INCLUDE.value(),
+                uhIdentifiers);
+        
+        List<HasMemberResult> filteredList = hasMembersResults.getExistingMembers();
+        
+        return GroupingMembers.fromFilteredResults(filteredList);
+        
+    }
+    
+    public GroupingMembers getMembersExistInExclude(String currentUser, String groupingPath,
+            List<String> uhIdentifiers) {
+        HasMembersResults hasMembersResults = grouperService.hasMembersResults(
+                currentUser,
+                groupingPath + GroupType.EXCLUDE.value(),
+                uhIdentifiers);
+        
+        List<HasMemberResult> filteredList = hasMembersResults.getExistingMembers();
+        
+        return GroupingMembers.fromFilteredResults(filteredList);
+    }
+    
+    public GroupingMembers getMembersExistInOwners(String currentUser, String groupingPath,
+            List<String> uhIdentifiers) {
+        HasMembersResults hasMembersResults = grouperService.hasMembersResults(
+                currentUser,
+                groupingPath + GroupType.OWNERS.value(),
+                uhIdentifiers);
+        
+        List<HasMemberResult> filteredList = hasMembersResults.getExistingMembers();
+        
+        return GroupingMembers.fromFilteredResults(filteredList);
+    }
+    
     /**
      * Get the opt attributes of a selected grouping.
      */

--- a/src/main/java/edu/hawaii/its/api/wrapper/HasMemberResult.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/HasMemberResult.java
@@ -13,6 +13,10 @@ public class HasMemberResult {
     public HasMemberResult() {
         this.wsHasMemberResult = new WsHasMemberResult();
     }
+    
+    public boolean isMember() {
+        return "IS_MEMBER".equalsIgnoreCase(getResultCode());
+    }
 
     public Subject getSubject() {
         if (wsHasMemberResult.getWsSubject() == null) {

--- a/src/main/java/edu/hawaii/its/api/wrapper/HasMembersResults.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/HasMembersResults.java
@@ -2,6 +2,7 @@ package edu.hawaii.its.api.wrapper;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import edu.internet2.middleware.grouperClient.ws.beans.WsGroup;
 import edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResult;
@@ -31,11 +32,17 @@ public class HasMembersResults extends Results {
         }
         return hasMembersResults;
     }
-
+    
+    public List<HasMemberResult> getExistingMembers() {
+        return getResults().stream()
+                .filter(HasMemberResult::isMember)
+                .collect(Collectors.toList());
+    }
+    
     @Override public String getResultCode() {
         return wsHasMemberResults.getResultMetadata().getResultCode();
     }
-
+    
     public String getGroupPath() {
         return getGroup().getGroupPath();
     }

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -6,11 +6,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.reset;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -25,39 +25,38 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 
-import edu.hawaii.its.api.configuration.SecurityTestConfig;
-import edu.hawaii.its.api.type.SortBy;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
-import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.web.context.WebApplicationContext;
 
+import edu.hawaii.its.api.configuration.SecurityTestConfig;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
 import edu.hawaii.its.api.groupings.GroupingAddResult;
 import edu.hawaii.its.api.groupings.GroupingAddResults;
 import edu.hawaii.its.api.groupings.GroupingDescription;
 import edu.hawaii.its.api.groupings.GroupingGroupMembers;
-import edu.hawaii.its.api.groupings.GroupingOwnerMembers;
 import edu.hawaii.its.api.groupings.GroupingGroupsMembers;
+import edu.hawaii.its.api.groupings.GroupingMembers;
 import edu.hawaii.its.api.groupings.GroupingMoveMembersResult;
 import edu.hawaii.its.api.groupings.GroupingOptAttributes;
+import edu.hawaii.its.api.groupings.GroupingOwnerMembers;
 import edu.hawaii.its.api.groupings.GroupingPaths;
 import edu.hawaii.its.api.groupings.GroupingRemoveResult;
 import edu.hawaii.its.api.groupings.GroupingRemoveResults;
 import edu.hawaii.its.api.groupings.GroupingReplaceGroupMembersResult;
 import edu.hawaii.its.api.groupings.GroupingUpdateDescriptionResult;
+import edu.hawaii.its.api.groupings.GroupingUpdateOptAttributeResult;
 import edu.hawaii.its.api.groupings.GroupingUpdateSyncDestResult;
 import edu.hawaii.its.api.groupings.GroupingUpdatedAttributeResult;
-import edu.hawaii.its.api.groupings.GroupingUpdateOptAttributeResult;
-
 import edu.hawaii.its.api.groupings.ManageSubjectResults;
 import edu.hawaii.its.api.groupings.MemberAttributeResults;
 import edu.hawaii.its.api.groupings.MembershipResults;
@@ -74,8 +73,9 @@ import edu.hawaii.its.api.service.UpdateMemberService;
 import edu.hawaii.its.api.type.Group;
 import edu.hawaii.its.api.type.Grouping;
 import edu.hawaii.its.api.type.GroupingPath;
-import edu.hawaii.its.api.type.OptType;
 import edu.hawaii.its.api.type.OptRequest;
+import edu.hawaii.its.api.type.OptType;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.PropertyLocator;
 import edu.hawaii.its.api.wrapper.FindGroupsResults;
@@ -99,10 +99,10 @@ public class GroupingsRestControllerv2_1Test {
 
     @Value("${groupings.api.releasedgrouping}")
     private String RELEASED_GROUPING;
-
+	
     @Value("${groupings.max.owner.limit}")
     private Integer OWNER_LIMIT;
-
+	
     @Value("${groupings.api.test.admin_user}")
     private String ADMIN;
 
@@ -299,8 +299,8 @@ public class GroupingsRestControllerv2_1Test {
         GroupingRemoveResult removeMemberResult = new GroupingRemoveResult();
         given(updateMemberService.removeAdminMember(ADMIN, adminToRemove))
                 .willReturn(removeMemberResult);
-
-        mockMvc.perform(delete(API_BASE + "/admins/" + adminToRemove))
+	    
+	    mockMvc.perform(delete(API_BASE + "/admins/" + adminToRemove))
                 .andExpect(status().isOk());
 
         verify(updateMemberService, times(1))
@@ -330,12 +330,12 @@ public class GroupingsRestControllerv2_1Test {
     public void resetIncludeGroupTest() throws Exception {
         GroupingReplaceGroupMembersResult result = new GroupingReplaceGroupMembersResult();
         given(updateMemberService.resetIncludeGroup(TEST_USER, "grouping")).willReturn(result);
-
+		
         MvcResult mvcResult = mockMvc.perform(delete(API_BASE + "/groupings/grouping/include"))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(mvcResult);
-
+		
         verify(updateMemberService, times(1)).resetIncludeGroup(TEST_USER, "grouping");
     }
 
@@ -345,12 +345,12 @@ public class GroupingsRestControllerv2_1Test {
         CompletableFuture<GroupingReplaceGroupMembersResult> completableFuture = new CompletableFuture<>();
         given(updateMemberService.resetIncludeGroupAsync(ADMIN, GROUPING))
                 .willReturn(completableFuture);
-
+		
         MvcResult mvcResult = mockMvc.perform(delete(API_BASE + "/groupings/" + GROUPING + "/include/async"))
                 .andExpect(status().isAccepted())
                 .andReturn();
         assertNotNull(mvcResult);
-
+		
         verify(updateMemberService, times(1)).resetIncludeGroupAsync(ADMIN, GROUPING);
     }
 
@@ -359,12 +359,12 @@ public class GroupingsRestControllerv2_1Test {
     public void resetExcludeGroupTest() throws Exception {
         GroupingReplaceGroupMembersResult result = new GroupingReplaceGroupMembersResult();
         given(updateMemberService.resetExcludeGroup(TEST_USER, "grouping")).willReturn(result);
-
+		
         MvcResult mvcResult = mockMvc.perform(delete(API_BASE + "/groupings/" + GROUPING + "/exclude"))
                 .andExpect(status().isOk())
                 .andReturn();
         assertNotNull(mvcResult);
-
+		
         verify(updateMemberService, times(1)).resetExcludeGroup(TEST_USER, GROUPING);
     }
 
@@ -379,7 +379,7 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(status().isAccepted())
                 .andReturn();
         assertNotNull(mvcResult);
-
+		
         verify(updateMemberService, times(1)).resetExcludeGroupAsync(ADMIN, GROUPING);
     }
 
@@ -500,8 +500,8 @@ public class GroupingsRestControllerv2_1Test {
     public void membershipResultsTest() throws Exception {
         MembershipResults memberships = new MembershipResults();
         given(membershipService.membershipResults(TEST_USER)).willReturn(memberships);
-
-        mockMvc.perform(get(API_BASE + "/members/memberships"))
+	    
+	    mockMvc.perform(get(API_BASE + "/members/memberships"))
                 .andExpect(status().isOk());
 
         verify(membershipService, times(1))
@@ -513,7 +513,7 @@ public class GroupingsRestControllerv2_1Test {
     public void manageSubjectResultsTest() throws Exception {
         ManageSubjectResults manageSubjectResults = new ManageSubjectResults();
         given(membershipService.manageSubjectResults(ADMIN, "testiwta")).willReturn(manageSubjectResults);
-
+		
         mockMvc.perform(get(API_BASE + "/members/testiwta/groupings"))
                 .andExpect(status().isOk());
 
@@ -674,12 +674,13 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithMockUhAdmin
     public void ownerGroupingsTest() throws Exception {
-        String path = "path:to:grouping";
+	    
+	    String path = "path:to:grouping";
         String description = "description";
 
         GroupingPaths groupingPaths = new GroupingPaths();
         groupingPaths.addGroupingPath(new GroupingPath(path, description));
-
+	    
         given(memberAttributeService.getOwnedGroupings(ADMIN))
                 .willReturn(groupingPaths);
         mockMvc.perform(get(API_BASE + "/owners/groupings")).andExpect(status().isOk())
@@ -700,11 +701,11 @@ public class GroupingsRestControllerv2_1Test {
         ownersToAdd.add("tst04name");
         ownersToAdd.add("tst05name");
         ownersToAdd.add("tst06name");
-
-        given(updateMemberService.addOwnerships(TEST_USER, "grouping", ownersToAdd))
+	    
+	    given(updateMemberService.addOwnerships(TEST_USER, "grouping", ownersToAdd))
                 .willReturn(groupingAddResults);
-
-        MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/" + String.join(",", ownersToAdd)))
+	    
+	    MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/" + String.join(",", ownersToAdd)))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -722,11 +723,11 @@ public class GroupingsRestControllerv2_1Test {
         ownerGroupingsToAdd.add("tmp:tst04name:groupPath04");
         ownerGroupingsToAdd.add("tmp:tst05name:groupPath05");
         ownerGroupingsToAdd.add("tmp:tst06name:groupPath06");
-
+	    
         given(updateMemberService.addOwnerGroupingOwnerships(TEST_USER, "grouping", ownerGroupingsToAdd))
                 .willReturn(groupingAddResults);
-
-        MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/owner-groupings/" + String.join(",", ownerGroupingsToAdd)))
+	    
+	    MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/owners/owner-groupings/" + String.join(",", ownerGroupingsToAdd)))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -738,24 +739,93 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithMockUhOwner
     public void removeOwnersTest() throws Exception {
-        List<String> ownersToRemove = new ArrayList<>();
-        GroupingRemoveResults groupingRemoveResults = new GroupingRemoveResults();
-        ownersToRemove.add("tst04name");
-        ownersToRemove.add("tst05name");
-        ownersToRemove.add("tst06name");
+	    List<String> ownersToRemove = new ArrayList<>();
+	    GroupingRemoveResults groupingRemoveResults = new GroupingRemoveResults();
+	    ownersToRemove.add("tst04name");
+	    ownersToRemove.add("tst05name");
+	    ownersToRemove.add("tst06name");
 
         given(updateMemberService.removeOwnerships(TEST_USER, "grouping", ownersToRemove))
-                .willReturn(groupingRemoveResults);
-
-        MvcResult result =
+			    .willReturn(groupingRemoveResults);
+	    
+	    MvcResult result =
                 mockMvc.perform(delete(API_BASE + "/groupings/grouping/owners/" + String.join(",", ownersToRemove)))
-                        .andExpect(status().isOk())
-                        .andReturn();
-        assertNotNull(result);
-        verify(updateMemberService, times(1))
+					    .andExpect(status().isOk())
+					    .andReturn();
+	    assertNotNull(result);
+	    verify(updateMemberService, times(1))
                 .removeOwnerships(TEST_USER, "grouping", ownersToRemove);
     }
-
+	
+	@Test
+	@WithMockUhOwner
+	public void getMembersExistInIncludeTest() throws Exception {
+		
+		List<String> uhIdentifiers = new ArrayList<>();
+		uhIdentifiers.add("testiwta");
+		uhIdentifiers.add("testiwtb");
+		uhIdentifiers.add("testiwtc");
+		
+		GroupingMembers groupingMembers = new GroupingMembers();
+		
+		given(groupingOwnerService.getMembersExistInInclude(TEST_USER, "grouping", uhIdentifiers))
+				.willReturn(groupingMembers);
+		
+		mockMvc.perform(post(API_BASE + "/groupings/grouping/include-members/in-list")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(uhIdentifiers)))
+				.andExpect(status().isOk());
+		
+		verify(groupingOwnerService, times(1))
+				.getMembersExistInInclude(TEST_USER, "grouping", uhIdentifiers);
+	}
+	
+	@Test
+	@WithMockUhOwner
+	public void getMembersExistInExcludeTest() throws Exception {
+		
+		List<String> uhIdentifiers = new ArrayList<>();
+		uhIdentifiers.add("testiwta");
+		uhIdentifiers.add("testiwtb");
+		uhIdentifiers.add("testiwtc");
+		
+		GroupingMembers groupingMembers = new GroupingMembers();
+		
+		given(groupingOwnerService.getMembersExistInExclude(TEST_USER, "grouping", uhIdentifiers))
+				.willReturn(groupingMembers);
+		
+		mockMvc.perform(post(API_BASE + "/groupings/grouping/exclude-members/in-list")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(uhIdentifiers)))
+				.andExpect(status().isOk());
+		
+		verify(groupingOwnerService, times(1))
+				.getMembersExistInExclude(TEST_USER, "grouping", uhIdentifiers);
+	}
+	
+	@Test
+	@WithMockUhOwner
+	public void getMembersExistInOwnersTest() throws Exception {
+		
+		List<String> uhIdentifiers = new ArrayList<>();
+		uhIdentifiers.add("testiwta");
+		uhIdentifiers.add("testiwtb");
+		uhIdentifiers.add("testiwtc");
+		
+		GroupingMembers groupingMembers = new GroupingMembers();
+		
+		given(groupingOwnerService.getMembersExistInOwners(TEST_USER, "grouping", uhIdentifiers))
+				.willReturn(groupingMembers);
+		
+		mockMvc.perform(post(API_BASE + "/groupings/grouping/owners/in-list")
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(uhIdentifiers)))
+				.andExpect(status().isOk());
+		
+		verify(groupingOwnerService, times(1))
+				.getMembersExistInOwners(TEST_USER, "grouping", uhIdentifiers);
+	}
+	
     @Test
     @WithMockUhOwner
     public void removeOwnerGroupingsTest() throws Exception {
@@ -764,7 +834,7 @@ public class GroupingsRestControllerv2_1Test {
         ownerGroupingsToAdd.add("tmp:tst04name:groupPath04");
         ownerGroupingsToAdd.add("tmp:tst05name:groupPath05");
         ownerGroupingsToAdd.add("tmp:tst06name:groupPath06");
-
+		
         given(updateMemberService.removeOwnerships(TEST_USER, "grouping", ownerGroupingsToAdd))
                 .willReturn(groupingRemoveResults);
 
@@ -781,8 +851,8 @@ public class GroupingsRestControllerv2_1Test {
     @WithMockUhOwner
     public void updateDescriptionTest() throws Exception {
         GroupingUpdateDescriptionResult groupingsUpdateDescriptionResult = new GroupingUpdateDescriptionResult();
-
-        given(groupingAttributeService.updateDescription("grouping", TEST_USER, "description")).willReturn(
+	    
+	    given(groupingAttributeService.updateDescription("grouping", TEST_USER, "description")).willReturn(
                 groupingsUpdateDescriptionResult);
         MvcResult result = mockMvc.perform(put(API_BASE + "/groupings/grouping/description")
                         .content("description"))
@@ -797,37 +867,37 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithMockUhOwner
     public void updateSyncDestTest() throws Exception {
-
+		
         given(groupingAttributeService.updateGroupingSyncDest(GROUPING, TEST_USER, LISTSERV, true))
                 .willReturn(new GroupingUpdateSyncDestResult(new GroupingUpdatedAttributeResult()));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/sync-destination/" + LISTSERV + "/true"))
                 .andExpect(status().isOk());
 
         verify(groupingAttributeService, times(1))
                 .updateGroupingSyncDest(GROUPING, TEST_USER, LISTSERV, true);
-
+	    
         given(groupingAttributeService.updateGroupingSyncDest(GROUPING, TEST_USER, LISTSERV, false))
                 .willReturn(new GroupingUpdateSyncDestResult(new GroupingUpdatedAttributeResult()));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/sync-destination/" + LISTSERV + "/false"))
                 .andExpect(status().isOk());
 
         verify(groupingAttributeService, times(1))
                 .updateGroupingSyncDest(GROUPING, TEST_USER, LISTSERV, false);
-
+		
         given(groupingAttributeService.updateGroupingSyncDest(GROUPING, TEST_USER, RELEASED_GROUPING, true))
                 .willReturn(new GroupingUpdateSyncDestResult(new GroupingUpdatedAttributeResult()));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/sync-destination/" + RELEASED_GROUPING + "/true"))
                 .andExpect(status().isOk());
 
         verify(groupingAttributeService, times(1))
                 .updateGroupingSyncDest(GROUPING, TEST_USER, RELEASED_GROUPING, true);
-
+		
         given(groupingAttributeService.updateGroupingSyncDest(GROUPING, TEST_USER, RELEASED_GROUPING, false))
                 .willReturn(new GroupingUpdateSyncDestResult(new GroupingUpdatedAttributeResult()));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/sync-destination/" + RELEASED_GROUPING + "/false"))
                 .andExpect(status().isOk());
 
@@ -841,7 +911,7 @@ public class GroupingsRestControllerv2_1Test {
         // case 1: id=IN, status=true
         given(groupingAttributeService.updateOptAttribute(any(OptRequest.class), any(OptRequest.class)))
                 .willReturn(mock(GroupingUpdateOptAttributeResult.class));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/opt-attribute/" + OptType.IN.value() + "/true"))
                 .andExpect(status().isOk());
 
@@ -852,7 +922,7 @@ public class GroupingsRestControllerv2_1Test {
         reset(groupingAttributeService);
         given(groupingAttributeService.updateOptAttribute(any(OptRequest.class), any(OptRequest.class)))
                 .willReturn(mock(GroupingUpdateOptAttributeResult.class));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/opt-attribute/" + OptType.IN.value() + "/false"))
                 .andExpect(status().isOk());
 
@@ -863,7 +933,7 @@ public class GroupingsRestControllerv2_1Test {
         reset(groupingAttributeService);
         given(groupingAttributeService.updateOptAttribute(any(OptRequest.class), any(OptRequest.class)))
                 .willReturn(mock(GroupingUpdateOptAttributeResult.class));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/opt-attribute/" + OptType.OUT.value() + "/true"))
                 .andExpect(status().isOk());
 
@@ -874,7 +944,7 @@ public class GroupingsRestControllerv2_1Test {
         reset(groupingAttributeService);
         given(groupingAttributeService.updateOptAttribute(any(OptRequest.class), any(OptRequest.class)))
                 .willReturn(mock(GroupingUpdateOptAttributeResult.class));
-
+		
         mockMvc.perform(put(API_BASE + "/groupings/" + GROUPING + "/opt-attribute/" + OptType.OUT.value() + "/false"))
                 .andExpect(status().isOk());
 
@@ -926,7 +996,7 @@ public class GroupingsRestControllerv2_1Test {
             groupingPathList.add(new GroupingPath(GROUPING));
         }
         given(memberAttributeService.numberOfGroupings(TEST_USER)).willReturn(10);
-
+		
         mockMvc.perform(get(API_BASE + "/owners/groupings/count"))
                 .andExpect(status().isOk());
         verify(memberAttributeService, times(1))
@@ -978,7 +1048,7 @@ public class GroupingsRestControllerv2_1Test {
 
         given(membershipService.numberOfMemberships(TEST_USER))
                 .willReturn(369);
-
+		
         mockMvc.perform(get(API_BASE + "/members/memberships/count"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("369"));
@@ -992,7 +1062,7 @@ public class GroupingsRestControllerv2_1Test {
     public void getNumberOfGroupingMembersTest() throws Exception {
         given(groupingOwnerService.numberOfGroupingMembers(ADMIN, GROUPING))
                 .willReturn(100);
-
+		
         mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/count"))
                 .andExpect(status().isOk())
                 .andExpect(content().string("100"));
@@ -1014,26 +1084,26 @@ public class GroupingsRestControllerv2_1Test {
     @Test
     @WithMockUhAdmin
     public void getNumberOfAllOwnersTest() throws Exception {
-        given(groupingAssignmentService.numberOfAllOwners(ADMIN, GROUPING)).willReturn(1);
-
-        MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/count"))
-                .andExpect(status().isOk())
-                .andReturn();
-
-        assertNotNull(mvcResult);
-        verify(groupingAssignmentService, times(1)).numberOfAllOwners(ADMIN, GROUPING);
+	    given(groupingAssignmentService.numberOfAllOwners(ADMIN, GROUPING)).willReturn(1);
+	    
+	    MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/count"))
+			    .andExpect(status().isOk())
+			    .andReturn();
+	    
+	    assertNotNull(mvcResult);
+	    verify(groupingAssignmentService, times(1)).numberOfAllOwners(ADMIN, GROUPING);
     }
-
-    @Test
-    @WithMockUhAdmin
-    public void compareOwnerGroupingsTest() throws Exception {
-        MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/compare"))
-                .andExpect(status().isOk())
-                .andReturn();
-        assertNotNull(mvcResult);
-        verify(groupingAssignmentService, times(1)).compareOwnerGroupings(ADMIN, GROUPING);
-    }
-
+	
+	@Test
+	@WithMockUhAdmin
+	public void compareOwnerGroupingsTest() throws Exception {
+		MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/compare"))
+				.andExpect(status().isOk())
+				.andReturn();
+		assertNotNull(mvcResult);
+		verify(groupingAssignmentService, times(1)).compareOwnerGroupings(ADMIN, GROUPING);
+	}
+	
     @Test
     @WithMockUhAdmin
     public void groupingOwnersTest() throws Exception {
@@ -1064,17 +1134,17 @@ public class GroupingsRestControllerv2_1Test {
                 .andExpect(status().is5xxServerError())
                 .andReturn();
         assertThat(result1, notNullValue());
-
+		
         MvcResult result2 = mockMvc.perform(get(API_BASE + "/owners/" + TEST_USER + "^" + "/groupings"))
                 .andExpect(status().is5xxServerError())
                 .andReturn();
         assertThat(result2, notNullValue());
-
+		
         MvcResult result3 = mockMvc.perform(get(API_BASE + "/members/" + TEST_USER + "}"))
                 .andExpect(status().is5xxServerError())
                 .andReturn();
         assertThat(result3, notNullValue());
-
+		
         MvcResult result4 = mockMvc.perform(get(API_BASE + "/members/" + TEST_USER + "@"))
                 .andExpect(status().is5xxServerError())
                 .andReturn();

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -50,7 +50,6 @@ import edu.hawaii.its.api.groupings.GroupingUpdateSyncDestResult;
 import edu.hawaii.its.api.groupings.ManageSubjectResults;
 import edu.hawaii.its.api.groupings.MemberAttributeResults;
 import edu.hawaii.its.api.groupings.MembershipResults;
-import edu.hawaii.its.api.groupings.OwnerResult;
 import edu.hawaii.its.api.service.GroupingAttributeService;
 import edu.hawaii.its.api.service.GroupingsService;
 import edu.hawaii.its.api.service.MemberService;
@@ -417,7 +416,62 @@ public class TestGroupingsRestControllerv2_1 {
         assertNotNull(mvcResult);
         assertNotNull(objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingMembers.class));
     }
-
+	
+	
+	@Test
+	@WithMockUhAdmin
+	public void getMembersExistInIncludeTest() throws Exception {
+		updateMemberService.addIncludeMembers(ADMIN, GROUPING, testUids);
+		String url = API_BASE_URL + "groupings/" + GROUPING + "/include-members/in-list";
+		MvcResult mvcResult = mockMvc.perform(post(url)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(testUids)))
+				.andExpect(status().isOk())
+				.andReturn();
+		assertNotNull(mvcResult);
+		GroupingMembers groupingMembers =
+				objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingMembers.class);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		updateMemberService.removeIncludeMembers(ADMIN, GROUPING, testUids);
+	}
+	
+	@Test
+	@WithMockUhAdmin
+	public void getMembersExistInExcludeTest() throws Exception {
+		updateMemberService.addExcludeMembers(ADMIN, GROUPING, testUids);
+		String url = API_BASE_URL + "groupings/" + GROUPING + "/exclude-members/in-list";
+		MvcResult mvcResult = mockMvc.perform(post(url)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(testUids)))
+				.andExpect(status().isOk())
+				.andReturn();
+		assertNotNull(mvcResult);
+		GroupingMembers groupingMembers =
+				objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingMembers.class);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		updateMemberService.removeExcludeMembers(ADMIN, GROUPING, testUids);
+	}
+	
+	@Test
+	@WithMockUhAdmin
+	public void getMembersExistInOwnersTest() throws Exception {
+		updateMemberService.addOwnerships(ADMIN, GROUPING, testUids);
+		String url = API_BASE_URL + "groupings/" + GROUPING + "/owners/in-list";
+		MvcResult mvcResult = mockMvc.perform(post(url)
+						.contentType(MediaType.APPLICATION_JSON)
+						.content(JsonUtil.asJson(testUids)))
+				.andExpect(status().isOk())
+				.andReturn();
+		assertNotNull(mvcResult);
+		GroupingMembers groupingMembers =
+				objectMapper.readValue(mvcResult.getResponse().getContentAsString(), GroupingMembers.class);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		updateMemberService.removeOwnerships(ADMIN, GROUPING, testUids);
+	}
+	
     @Test
     @WithMockUhAdmin
     public void membershipResultsTest() throws Exception {

--- a/src/test/java/edu/hawaii/its/api/groupings/GroupingMemberTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/GroupingMemberTest.java
@@ -13,6 +13,8 @@ import org.springframework.test.context.ActiveProfiles;
 
 import edu.hawaii.its.api.configuration.GroupingsTestConfiguration;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.wrapper.HasMemberResult;
+import edu.hawaii.its.api.wrapper.HasMembersResults;
 import edu.hawaii.its.api.wrapper.Subject;
 
 @ActiveProfiles("localTest")
@@ -44,13 +46,121 @@ public class GroupingMemberTest {
         assertEquals(TEST_NAMES.get(0).split(" ")[0], groupingMember.getFirstName());
         assertEquals(TEST_NAMES.get(0).split(" ")[1], groupingMember.getLastName());
         assertEquals("Include", groupingMember.getWhereListed());
-
-        groupingMember = new GroupingMember();
+    }
+	
+	@Test
+	public void constructorWithHasMemberResult() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		HasMemberResult hasMemberResult = hasMembersResults.getResults().get(0);
+		GroupingMember groupingMember = new GroupingMember(hasMemberResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals(TEST_UH_UUIDS.get(0), groupingMember.getUhUuid());
+		assertEquals(TEST_NAMES.get(0), groupingMember.getName());
+		assertEquals(TEST_NAMES.get(0).split(" ")[0], groupingMember.getFirstName());
+		assertEquals(TEST_NAMES.get(0).split(" ")[1], groupingMember.getLastName());
+		assertEquals("Include", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithHasMemberResultNotMember() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		HasMemberResult hasMemberResult = hasMembersResults.getResults().get(0);
+		GroupingMember groupingMember = new GroupingMember(hasMemberResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals("", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithTwoHasMemberResults() {
+		HasMembersResults basisResults = groupingsTestConfiguration.hasMemberResultsIsMembersBasisTestData();
+		HasMembersResults includeResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		HasMemberResult basisResult = basisResults.getResults().get(0);
+		HasMemberResult includeResult = includeResults.getResults().get(0);
+		
+		GroupingMember groupingMember = new GroupingMember(basisResult, "basis", includeResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals(TEST_UH_UUIDS.get(0), groupingMember.getUhUuid());
+		assertEquals(TEST_NAMES.get(0), groupingMember.getName());
+		assertEquals("Basis & Include", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithTwoHasMemberResultsOnlyBasis() {
+		HasMembersResults basisResults = groupingsTestConfiguration.hasMemberResultsIsMembersBasisTestData();
+		HasMembersResults notIncludeResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		HasMemberResult basisResult = basisResults.getResults().get(0);
+		HasMemberResult notIncludeResult = notIncludeResults.getResults().get(0);
+		
+		GroupingMember groupingMember = new GroupingMember(basisResult, "basis", notIncludeResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals("Basis", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithTwoHasMemberResultsOnlyInclude() {
+		HasMembersResults notBasisResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersBasisTestData();
+		HasMembersResults includeResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		HasMemberResult notBasisResult = notBasisResults.getResults().get(0);
+		HasMemberResult includeResult = includeResults.getResults().get(0);
+		
+		GroupingMember groupingMember = new GroupingMember(notBasisResult, "basis", includeResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals("Include", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithTwoHasMemberResultsNeither() {
+		HasMembersResults notBasisResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersBasisTestData();
+		HasMembersResults notIncludeResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		HasMemberResult notBasisResult = notBasisResults.getResults().get(0);
+		HasMemberResult notIncludeResult = notIncludeResults.getResults().get(0);
+		
+		GroupingMember groupingMember = new GroupingMember(notBasisResult, "basis", notIncludeResult, "include");
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals("", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void constructorWithHasMemberResultOnly() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		HasMemberResult hasMemberResult = hasMembersResults.getResults().get(0);
+		GroupingMember groupingMember = new GroupingMember(hasMemberResult);
+		
+		assertNotNull(groupingMember);
+		assertEquals(TEST_UIDS.get(0), groupingMember.getUid());
+		assertEquals(TEST_UH_UUIDS.get(0), groupingMember.getUhUuid());
+		assertEquals(TEST_NAMES.get(0), groupingMember.getName());
+		assertEquals(TEST_NAMES.get(0).split(" ")[0], groupingMember.getFirstName());
+		assertEquals(TEST_NAMES.get(0).split(" ")[1], groupingMember.getLastName());
+		assertEquals("", groupingMember.getWhereListed());
+	}
+	
+	@Test
+	public void defaultConstructor() {
+		GroupingMember groupingMember = new GroupingMember();
         assertNotNull(groupingMember);
         assertNotNull(groupingMember.getName());
         assertNotNull(groupingMember.getUhUuid());
         assertNotNull(groupingMember.getUid());
         assertNotNull(groupingMember.getWhereListed());
+		assertEquals("", groupingMember.getName());
+		assertEquals("", groupingMember.getUhUuid());
+		assertEquals("", groupingMember.getUid());
+		assertEquals("", groupingMember.getWhereListed());
+		assertEquals("", groupingMember.getFirstName());
+		assertEquals("", groupingMember.getLastName());
     }
 
 }

--- a/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
@@ -318,4 +318,64 @@ public class GroupingOwnerServiceTest {
         assertEquals("test-attribute", destination.getName());
         assertEquals("Test description with test-group", destination.getDescription());
     }
+	
+	@Test
+	public void getMembersExistInIncludeTest() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.INCLUDE.value(), TEST_UIDS);
+		
+		GroupingMembers groupingMembers = groupingOwnerService.getMembersExistInInclude(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		assertEquals(TEST_UIDS.size(), groupingMembers.getMembers().size());
+		
+		hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.INCLUDE.value(), TEST_UIDS);
+		
+		groupingMembers = groupingOwnerService.getMembersExistInInclude(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertTrue(groupingMembers.getMembers().isEmpty());
+	}
+	
+	@Test
+	public void getMembersExistInExcludeTest() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.EXCLUDE.value(), TEST_UIDS);
+		
+		GroupingMembers groupingMembers = groupingOwnerService.getMembersExistInExclude(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		assertEquals(TEST_UIDS.size(), groupingMembers.getMembers().size());
+		
+		hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.EXCLUDE.value(), TEST_UIDS);
+		
+		groupingMembers = groupingOwnerService.getMembersExistInExclude(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertTrue(groupingMembers.getMembers().isEmpty());
+	}
+	
+	@Test
+	public void getMembersExistInOwnersTest() {
+		HasMembersResults hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.OWNERS.value(), TEST_UIDS);
+		
+		GroupingMembers groupingMembers = groupingOwnerService.getMembersExistInOwners(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertFalse(groupingMembers.getMembers().isEmpty());
+		assertEquals(TEST_UIDS.size(), groupingMembers.getMembers().size());
+		
+		hasMembersResults = groupingsTestConfiguration.hasMemberResultsIsNotMembersUidTestData();
+		doReturn(hasMembersResults).when(grouperService)
+				.hasMembersResults(ADMIN, groupingPath + GroupType.OWNERS.value(), TEST_UIDS);
+		
+		groupingMembers = groupingOwnerService.getMembersExistInOwners(ADMIN, groupingPath, TEST_UIDS);
+		assertNotNull(groupingMembers);
+		assertTrue(groupingMembers.getMembers().isEmpty());
+	}
 }

--- a/src/test/java/edu/hawaii/its/api/wrapper/HasMemberResultTest.java
+++ b/src/test/java/edu/hawaii/its/api/wrapper/HasMemberResultTest.java
@@ -1,7 +1,9 @@
 package edu.hawaii.its.api.wrapper;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -10,6 +12,7 @@ import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.PropertyLocator;
 
 import edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResult;
+import edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResults;
 
 public class HasMemberResultTest {
 
@@ -40,4 +43,28 @@ public class HasMemberResultTest {
         assertEquals("", hasMemberResult.getResultCode());
         assertNotNull(hasMemberResult.getSubject());
     }
+	
+	@Test
+	public void isMemberReturnsTrue() {
+		String json = propertyLocator.find("ws.has.member.results.is.members.uid");
+		WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
+		assertNotNull(wsHasMemberResults);
+		WsHasMemberResult wsHasMemberResult = wsHasMemberResults.getResults()[0];
+		HasMemberResult hasMemberResult = new HasMemberResult(wsHasMemberResult);
+		assertNotNull(hasMemberResult);
+		assertEquals("IS_MEMBER", hasMemberResult.getResultCode());
+		assertTrue(hasMemberResult.isMember());
+	}
+	
+	@Test
+	public void isMemberReturnsFalse() {
+		String json = propertyLocator.find("ws.has.member.results.is.not.members.uid");
+		WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
+		assertNotNull(wsHasMemberResults);
+		WsHasMemberResult wsHasMemberResult = wsHasMemberResults.getResults()[0];
+		HasMemberResult hasMemberResult = new HasMemberResult(wsHasMemberResult);
+		assertNotNull(hasMemberResult);
+		assertEquals("IS_NOT_MEMBER", hasMemberResult.getResultCode());
+		assertFalse(hasMemberResult.isMember());
+	}
 }

--- a/src/test/java/edu/hawaii/its/api/wrapper/HasMembersResultsTest.java
+++ b/src/test/java/edu/hawaii/its/api/wrapper/HasMembersResultsTest.java
@@ -113,5 +113,71 @@ public class HasMembersResultsTest {
         assertEquals("FAILURE", hasMembersResults.getGroup().getResultCode());
         assertEquals("", hasMembersResults.getGroupPath());
     }
-
+	
+	@Test
+	public void getExistingMembersWithMembers() {
+		String json = propertyLocator.find("ws.has.member.results.is.members.uid");
+		WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
+		HasMembersResults hasMembersResults = new HasMembersResults(wsHasMemberResults);
+		assertNotNull(hasMembersResults);
+		
+		List<HasMemberResult> existingMembers = hasMembersResults.getExistingMembers();
+		assertNotNull(existingMembers);
+		assertEquals(5, existingMembers.size());
+		
+		for (HasMemberResult result : existingMembers) {
+			assertEquals("IS_MEMBER", result.getResultCode());
+		}
+	}
+	
+	@Test
+	public void getExistingMembersWithNoMembers() {
+		String json = propertyLocator.find("ws.has.member.results.is.not.members.uid");
+		WsHasMemberResults wsHasMemberResults = JsonUtil.asObject(json, WsHasMemberResults.class);
+		HasMembersResults hasMembersResults = new HasMembersResults(wsHasMemberResults);
+		assertNotNull(hasMembersResults);
+		
+		List<HasMemberResult> existingMembers = hasMembersResults.getExistingMembers();
+		assertNotNull(existingMembers);
+		assertEquals(0, existingMembers.size());
+	}
+	
+	@Test
+	public void getExistingMembersWithMixedResults() {
+		String jsonMembers = propertyLocator.find("ws.has.member.results.is.members.uid");
+		String jsonNonMembers = propertyLocator.find("ws.has.member.results.is.not.members.uid");
+		
+		WsHasMemberResults wsMemberResults = JsonUtil.asObject(jsonMembers, WsHasMemberResults.class);
+		WsHasMemberResults wsNonMemberResults = JsonUtil.asObject(jsonNonMembers, WsHasMemberResults.class);
+		
+		WsHasMemberResults wsMixedResults = new WsHasMemberResults();
+		wsMixedResults.setResultMetadata(wsMemberResults.getResultMetadata());
+		wsMixedResults.setWsGroup(wsMemberResults.getWsGroup());
+		
+		int totalResults = 5;
+		edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResult[] mixedResults =
+				new edu.internet2.middleware.grouperClient.ws.beans.WsHasMemberResult[totalResults];
+		mixedResults[0] = wsMemberResults.getResults()[0];
+		mixedResults[1] = wsMemberResults.getResults()[1];
+		mixedResults[2] = wsNonMemberResults.getResults()[0];
+		mixedResults[3] = wsMemberResults.getResults()[2];
+		mixedResults[4] = wsNonMemberResults.getResults()[1];
+		
+		wsMixedResults.setResults(mixedResults);
+		
+		HasMembersResults hasMembersResults = new HasMembersResults(wsMixedResults);
+		assertNotNull(hasMembersResults);
+		
+		List<HasMemberResult> allResults = hasMembersResults.getResults();
+		assertEquals(5, allResults.size());
+		
+		List<HasMemberResult> existingMembers = hasMembersResults.getExistingMembers();
+		assertNotNull(existingMembers);
+		assertEquals(3, existingMembers.size());
+		
+		for (HasMemberResult result : existingMembers) {
+			assertEquals("IS_MEMBER", result.getResultCode());
+		}
+	}
+	
 }


### PR DESCRIPTION

# Ticket Link

[GROUPINGS-1922](https://uhawaii.atlassian.net/browse/GROUPINGS-1922?atlOrigin=eyJpIjoiN2JjYmZkMTFkMjRjNDhlMGJlZTAyZDcxMzM2ZTFhNDMiLCJwIjoiaiJ9)

# List of squashed commits
- Squashing finished, functioning code, no tests yet.
- added members-exist endpoints in rest controller for include, exclude, and owners
- fixed owners members exist endpoint comment
- renamed endpoint paths members-exist to in-list
- clean up unused code, comments
- add getMembersExistInInclude, exclude and owners tests to groupingsrestcontrollerv2_1 test
- update gropuingsmember and groupingowner service test
- add tests for IS_MEMBER method in HasMember and Members Result tests
- update integration test for groupingsrestcontrollerv2-1 , add WithMockUhAdmin to getMembersExist tests
- clean up code, remove comments
- fix errors after mockwithuhowner merges

# Test Checklist

- [ ] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [ ] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [ ] Tested For Incorrect/Unexpected Inputs:
