### PR TITLE
Filter out DIRECT owners from duplicate owners list table

### DIFF
--- a/src/main/java/edu/hawaii/its/api/groupings/OwnerResult.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/OwnerResult.java
@@ -10,11 +10,10 @@ public class OwnerResult {
     private final String uid;
     private final List<String> paths = new ArrayList<>();
 
-    public OwnerResult(String uhUuid, String name, String uid, String initialPath) {
+    public OwnerResult(String uhUuid, String name, String uid) {
         this.uhUuid = uhUuid;
         this.name = name;
         this.uid = uid;
-        this.paths.add(initialPath);
     }
 
     public String getUhUuid() {
@@ -37,4 +36,3 @@ public class OwnerResult {
         this.paths.add(path);
     }
 }
-

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -198,8 +198,7 @@ public class GroupingAssignmentService {
                 ownerGroupings.add(name);
                 continue;
             }
-            // For direct owners, we intentionally leave OwnerResult.paths empty (no initial path)
-            // to indicate a DIRECT ownership source; only owner-grouping sources add paths below.
+            // For direct owners, we do not add a path to indicate DIRECT ownership; only owner-groupings add a path below.
             existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, name, owner.getUid()));
         }
 

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -198,6 +198,8 @@ public class GroupingAssignmentService {
                 ownerGroupings.add(name);
                 continue;
             }
+            // For direct owners, we intentionally leave OwnerResult.paths empty (no initial path)
+            // to indicate a DIRECT ownership source; only owner-grouping sources add paths below.
             existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, name, owner.getUid()));
         }
 
@@ -216,8 +218,9 @@ public class GroupingAssignmentService {
                     duplicates.get(uhUuid).addPath(path);
                 } else {
                     // Place it in existing map if it's seen for the first time
-                    existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, owner.getName(), owner.getUid()));
-                    existingUhUuids.get(uhUuid).addPath(path);
+                    OwnerResult ownerResult = new OwnerResult(uhUuid, owner.getName(), owner.getUid());
+                    ownerResult.addPath(path);
+                    existingUhUuids.put(uhUuid, ownerResult);
                 }
             }
         }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -198,7 +198,7 @@ public class GroupingAssignmentService {
                 ownerGroupings.add(name);
                 continue;
             }
-            existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, name, owner.getUid(), "DIRECT"));
+            existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, name, owner.getUid()));
         }
 
         // Iterate through each owner-grouping to find duplicate owners
@@ -216,7 +216,8 @@ public class GroupingAssignmentService {
                     duplicates.get(uhUuid).addPath(path);
                 } else {
                     // Place it in existing map if it's seen for the first time
-                    existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, owner.getName(), owner.getUid(), path));
+                    existingUhUuids.put(uhUuid, new OwnerResult(uhUuid, owner.getName(), owner.getUid()));
+                    existingUhUuids.get(uhUuid).addPath(path);
                 }
             }
         }

--- a/src/test/java/edu/hawaii/its/api/groupings/OwnerResultTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/OwnerResultTest.java
@@ -7,14 +7,15 @@ public class OwnerResultTest {
     @Test
     public void testOwnerResultConstructor() {
         OwnerResult ownerResult = new OwnerResult(
-                "99997010", "Testf-iwt-a TestIAM-staff", "testiwta", "path:to:grouping1"
-        );
+                "99997010", "Testf-iwt-a TestIAM-staff", "testiwta");
         assert ownerResult.getUhUuid().equals("99997010");
         assert ownerResult.getName().equals("Testf-iwt-a TestIAM-staff");
         assert ownerResult.getUid().equals("testiwta");
+        assert ownerResult.getPaths().isEmpty();
+
+        ownerResult.addPath("path:to:grouping1");
         assert ownerResult.getPaths().size() == 1;
         assert ownerResult.getPaths().get(0).equals("path:to:grouping1");
-
         ownerResult.addPath("path:to:grouping2");
         assert ownerResult.getPaths().size() == 2;
         assert ownerResult.getPaths().get(1).equals("path:to:grouping2");

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
@@ -355,5 +355,9 @@ public class TestGroupingAssignmentService {
         assertTrue(duplicates.containsKey(duplicateOwnerUhUuid));
         assertEquals(duplicates.get(duplicateOwnerUhUuid).getUhUuid(), duplicateOwnerUhUuid);
         assertTrue(duplicates.get(duplicateOwnerUhUuid).getPaths().contains(OWNER_GROUPING));
+        assertTrue(duplicates.get(duplicateOwnerUhUuid).getPaths().contains(OWNER_GROUPING));
+        assertTrue(duplicates.get(duplicateOwnerUhUuid).getPaths()
+                .stream()
+                .noneMatch(path -> path.contains("DIRECT")));
     }
 }

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
@@ -226,7 +226,7 @@ public class TestGroupingAssignmentService {
         GroupingOwnerMembers ownersWithGroup = groupingAssignmentService.groupingImmediateOwners(ADMIN, GROUPING);
         assertNotNull(ownersWithGroup);
         assertTrue(ownersWithGroup.getOwners().getMembers().stream()
-                        .anyMatch(member ->OWNER_GROUPING.equals(member.getName())));
+                .anyMatch(member ->OWNER_GROUPING.equals(member.getName())));
 
         updateMemberService.removeOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
         ownersWithGroup = groupingAssignmentService.groupingImmediateOwners(ADMIN, GROUPING);
@@ -354,7 +354,6 @@ public class TestGroupingAssignmentService {
         assertEquals(initialDuplicatesCount + 1, duplicates.size());
         assertTrue(duplicates.containsKey(duplicateOwnerUhUuid));
         assertEquals(duplicates.get(duplicateOwnerUhUuid).getUhUuid(), duplicateOwnerUhUuid);
-        assertTrue(duplicates.get(duplicateOwnerUhUuid).getPaths().contains("DIRECT"));
         assertTrue(duplicates.get(duplicateOwnerUhUuid).getPaths().contains(OWNER_GROUPING));
     }
 }


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/jira/software/c/projects/GROUPINGS/boards/18?quickFilter=75&selectedIssue=GROUPINGS-2138&useStoredSettings=true)

# List of squashed commits

- applied zhongyu changes to filtering DIRECT in api

# Test Checklist

- [ ] Exhibits Clear Code Structure:
- [ ] Project Unit Tests Passed:
- [ ] Project Integration Tests Passed:
- [ ] Executes Expected Functionality:
- [ ] Tested For Incorrect/Unexpected Inputs:
