### PR TITLE
Improve resource naming for duplicate owners endpoint

### DIFF
--- a/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
+++ b/src/main/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1.java
@@ -790,14 +790,14 @@ public class GroupingsRestControllerv2_1 {
      * Get all duplicated owners in a grouping, and their sources of ownership.
      * (Either both a direct owner and indirect owner, or multiple indirect owners via different owner-groupings.)
      */
-    @GetMapping(value = "/groupings/{path:[\\w-:.]+}/owners/compare")
-    public ResponseEntity<Map<String, OwnerResult>> compareOwnerGroupings(@PathVariable String path) {
-        logger.info("Entered REST compareOwnerGroupings...");
+    @GetMapping(value = "/groupings/{path:[\\w-:.]+}/owners/duplicates")
+    public ResponseEntity<Map<String, OwnerResult>> getDuplicateOwners(@PathVariable String path) {
+        logger.info("Entered REST getDuplicateOwners...");
         String currentUser = SecurityContextHolder.getContext().getAuthentication().getName();
 
         return ResponseEntity
                 .ok()
-                .body(groupingAssignmentService.compareOwnerGroupings(currentUser, path));
+                .body(groupingAssignmentService.getDuplicateOwners(currentUser, path));
     }
 
     /**

--- a/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingAssignmentService.java
@@ -175,12 +175,11 @@ public class GroupingAssignmentService {
     }
 
     /**
-     * Compare direct owners and owner-groupings
      * Returns a Map of all owners with multiple ownerships and sources of ownership for those owners.
      * The value is an OwnerResult object containing the owner's details and list of paths that make them an owner.
      */
-    public Map<String, OwnerResult> compareOwnerGroupings(String currentUser, String groupPath) {
-        logger.info(String.format("compareOwnerGroupings; currentUser: %s; groupPath: %s;",
+    public Map<String, OwnerResult> getDuplicateOwners(String currentUser, String groupPath) {
+        logger.info(String.format("getDuplicateOwners; currentUser: %s; groupPath: %s;",
                 currentUser, groupPath));
         if (!memberService.isAdmin(currentUser) && !memberService.isOwner(groupPath, currentUser)) {
             throw new AccessDeniedException();

--- a/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
+++ b/src/test/java/edu/hawaii/its/api/controller/GroupingsRestControllerv2_1Test.java
@@ -1092,12 +1092,12 @@ public class GroupingsRestControllerv2_1Test {
 	
 	@Test
 	@WithMockUhAdmin
-	public void compareOwnerGroupingsTest() throws Exception {
-		MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/compare"))
+	public void getDuplicateOwnersTest() throws Exception {
+		MvcResult mvcResult = mockMvc.perform(get(API_BASE + "/groupings/" + GROUPING + "/owners/duplicates"))
 				.andExpect(status().isOk())
 				.andReturn();
 		assertNotNull(mvcResult);
-		verify(groupingAssignmentService, times(1)).compareOwnerGroupings(ADMIN, GROUPING);
+		verify(groupingAssignmentService, times(1)).getDuplicateOwners(ADMIN, GROUPING);
 	}
 	
     @Test

--- a/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
+++ b/src/test/java/edu/hawaii/its/api/controller/TestGroupingsRestControllerv2_1.java
@@ -892,8 +892,8 @@ public class TestGroupingsRestControllerv2_1 {
 
     @Test
     @WithMockUhAdmin
-    public void compareOwnerGroupingsTest() throws Exception {
-        String url = API_BASE_URL + "/groupings/" + GROUPING + "/owners/compare";
+    public void getDuplicateOwners() throws Exception {
+        String url = API_BASE_URL + "/groupings/" + GROUPING + "/owners/duplicates";
         MvcResult mvcResult = mockMvc.perform(get(url)
                         )
                 .andExpect(status().isOk()).andReturn();

--- a/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
+++ b/src/test/java/edu/hawaii/its/api/service/TestGroupingAssignmentService.java
@@ -298,7 +298,7 @@ public class TestGroupingAssignmentService {
 
         //Owner-Grouping
         updateMemberService.addOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
-        int duplicateOwners = groupingAssignmentService.compareOwnerGroupings(ADMIN, GROUPING).size();
+        int duplicateOwners = groupingAssignmentService.getDuplicateOwners(ADMIN, GROUPING).size();
         int afterAdd = groupingAssignmentService.numberOfAllOwners(ADMIN, GROUPING);
         assertEquals(initialOwners + basisMembers + includeMembers - duplicateOwners, afterAdd);
         updateMemberService.removeOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
@@ -325,7 +325,7 @@ public class TestGroupingAssignmentService {
     }
 
     @Test
-    public void compareOwnerGroupingsTest() {
+    public void getDuplicateOwnersTest() {
         grouperService.removeMember(ADMIN, GROUPING_OWNERS, testUid);
         updateMemberService.removeOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
 
@@ -342,13 +342,13 @@ public class TestGroupingAssignmentService {
         grouperService.removeMember(ADMIN, GROUPING_OWNERS, duplicateOwnerUhUuid);
 
         updateMemberService.addOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
-        int initialDuplicatesCount = groupingAssignmentService.compareOwnerGroupings(ADMIN, GROUPING).size();
+        int initialDuplicatesCount = groupingAssignmentService.getDuplicateOwners(ADMIN, GROUPING).size();
 
         // Add the member as a direct owner to create the duplicate (member is already in OWNER_GROUPING).
         grouperService.addMember(ADMIN, GROUPING_OWNERS, duplicateOwnerUhUuid);
 
         Map<String, OwnerResult> duplicates =
-                groupingAssignmentService.compareOwnerGroupings(ADMIN, GROUPING);
+                groupingAssignmentService.getDuplicateOwners(ADMIN, GROUPING);
         grouperService.removeMember(ADMIN, GROUPING_OWNERS, duplicateOwnerUhUuid);
         updateMemberService.removeOwnerGroupingOwnerships(ADMIN, GROUPING, List.of(OWNER_GROUPING));
         assertEquals(initialDuplicatesCount + 1, duplicates.size());


### PR DESCRIPTION
# [Groupings-2139, Update compareOwnerGroupings endpoint and name](https://uhawaii.atlassian.net/browse/GROUPINGS-2139)

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-2139)

# List of squashed commits

- Adjusted names and endpoints for duplicates method


# Test Checklist

- [X] Exhibits Clear Code Structure:
- [X] Project Unit Tests Passed:
- [X] Project Jasmine Tests Passed:
- [X] Executes Expected Functionality:
- [X] Tested For Incorrect/Unexpected Inputs:
