### PR TITLE
Fix sync destination tooltip not based on JSON value specified

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -181,15 +181,20 @@ public class GroupingOwnerService {
             GroupAttributeResults groupAttributeResults) {
         List<AttributesResult> attributesResults = findAttributesResults.getResults();
         List<GroupingSyncDestination> syncDestinationList = new ArrayList<>();
+        String groupExtension = groupAttributeResults.getGroups().stream()
+                .findFirst()
+                .map(Group::getExtension)
+                .orElse("");
         for (AttributesResult attributesResult : attributesResults) {
             GroupingSyncDestination groupingSyncDestination =
                     JsonUtil.asObject(attributesResult.getDescription(), GroupingSyncDestination.class);
             groupingSyncDestination.setName(attributesResult.getName());
             groupingSyncDestination.setDescription(groupingSyncDestination.getDescription()
-                    .replaceFirst("\\$\\{srhfgs}", groupAttributeResults.getGroups().stream()
-                            .findFirst()
-                            .map(Group::getExtension)
-                            .orElse("")));
+                    .replaceFirst("\\$\\{srhfgs}", groupExtension));
+            if (groupingSyncDestination.getTooltip() != null) {
+                groupingSyncDestination.setTooltip(groupingSyncDestination.getTooltip()
+                        .replaceFirst("\\$\\{srhfgs}", groupExtension));
+            }
             groupingSyncDestination.setSynced(groupAttributeResults.getGroupAttributes().stream()
                     .anyMatch(groupAttribute -> groupAttribute.getAttributeName().equals(attributesResult.getName())));
             syncDestinationList.add(groupingSyncDestination);

--- a/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
@@ -306,6 +306,7 @@ public class GroupingOwnerServiceTest {
 
         GroupingSyncDestination mockDestination = new GroupingSyncDestination();
         mockDestination.setDescription("Test description with ${srhfgs}");
+        mockDestination.setTooltip("Test tooltip for ${srhfgs}");
         when(attributesResult.getDescription()).thenReturn(JsonUtil.asJson(mockDestination));
         when(attributesResult.getName()).thenReturn("test-attribute");
 
@@ -317,5 +318,6 @@ public class GroupingOwnerServiceTest {
         GroupingSyncDestination destination = result.get(0);
         assertEquals("test-attribute", destination.getName());
         assertEquals("Test description with test-group", destination.getDescription());
+        assertEquals("Test tooltip for test-group", destination.getTooltip());
     }
 }


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/jira/software/c/projects/GROUPINGS/boards/18?quickFilter=75&selectedIssue=GROUPINGS-2184&useStoredSettings=true)

# List of squashed commits

- changed how the description of sync destination is retrieved and sent as well as altered a test

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
