### PR TITLE
Fix duplicated grouping list path

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -1,5 +1,7 @@
 package edu.hawaii.its.api.service;
 
+import static edu.hawaii.its.api.service.PathFilter.parentGroupingPath;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -112,8 +114,10 @@ public class GroupingOwnerService {
                 "getGroupingMembers; currentUser: %s; groupingPath: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b; searchString: %s;",
                 currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending, searchString));
 
-        // Check specific grouping ownership (Grouper) OR general admin role (JWT)
-        if (!memberService.isCurrentUserAdmin() && !memberService.isOwner(groupingPath, currentUser)) {
+        // groupingPath may be a composite path (e.g. "grouping:owners"), so use the parent
+        // grouping path for the ownership check to avoid appending ":owners" twice.
+        if (!memberService.isCurrentUserAdmin()
+                && !memberService.isOwner(parentGroupingPath(groupingPath), currentUser)) {
             throw new AccessDeniedException();
         }
 

--- a/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -182,6 +183,36 @@ public class GroupingOwnerServiceTest {
         assertThrows(AccessDeniedException.class,
                 () -> groupingOwnerService.getGroupingMembers(
                         TEST_UIDS.get(0), groupingPath, pageNumber, pageSize, sortString, isAscending, searchString));
+    }
+
+    // A composite group path must have its ownership check run against the parent grouping path.
+    @Test
+    public void getGroupingMembersNormalizesCompositePathTest() {
+        Integer pageNumber = 1;
+        Integer pageSize = 10;
+        String sortString = "name";
+        Boolean isAscending = true;
+        String searchString = "test";
+
+        SubjectsResults subjectsResults = groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+
+        for (GroupType groupType : List.of(GroupType.OWNERS, GroupType.INCLUDE, GroupType.EXCLUDE, GroupType.BASIS)) {
+            clearInvocations(memberService);
+            String compositePath = groupingPath + groupType.value();
+
+            doReturn(subjectsResults).when(grouperService).getSubjects(compositePath, searchString);
+            doReturn(false).when(memberService).isCurrentUserAdmin();
+            // Only the parent grouping path grants ownership, not the composite path.
+            doReturn(true).when(memberService).isOwner(groupingPath, TEST_UIDS.get(0));
+            doReturn(false).when(memberService).isOwner(compositePath, TEST_UIDS.get(0));
+
+            GroupingGroupMembers groupingGroupMembers = groupingOwnerService.getGroupingMembers(
+                    TEST_UIDS.get(0), compositePath, pageNumber, pageSize, sortString, isAscending, searchString);
+
+            assertNotNull(groupingGroupMembers);
+            verify(memberService).isOwner(groupingPath, TEST_UIDS.get(0));
+            verify(memberService, never()).isOwner(compositePath, TEST_UIDS.get(0));
+        }
     }
 
     @Test


### PR DESCRIPTION
# Ticket Link

[2212](https://uhawaii.atlassian.net/browse/GROUPINGS-2212?atlOrigin=eyJpIjoiZGVhN2VkNjg2NjhkNDI5MDk3NzY4MTg1NDkxYzhlYTIiLCJwIjoiaiJ9)

# List of squashed commits

- fixed duplicated grouping list path by using parent grouping path for ownership check in getGroupingMembers using parentGroupingPath

# Test Checklist

- [x] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [x] Project Integration Tests Passed:
- [x] Executes Expected Functionality:
- [x] Tested For Incorrect/Unexpected Inputs:
