### PR TITLE
Backport (#728) to fix duplicated grouping list path

### DIFF
--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -1,5 +1,7 @@
 package edu.hawaii.its.api.service;
 
+import static edu.hawaii.its.api.service.PathFilter.parentGroupingPath;
+
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -107,7 +109,10 @@ public class GroupingOwnerService {
             "getGroupingMembers; currentUser: %s; groupingPath: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b; searchString: %s;",
             currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending, searchString));
 
-        if (!memberService.isAdmin(currentUser) && !memberService.isOwner(groupingPath, currentUser)) {
+        // groupingPath may be a composite path (e.g. "grouping:owners"), so use the parent
+        // grouping path for the ownership check to avoid appending ":owners" twice.
+        if (!memberService.isAdmin(currentUser)
+                && !memberService.isOwner(parentGroupingPath(groupingPath), currentUser)) {
             throw new AccessDeniedException();
         }
 

--- a/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
+++ b/src/test/java/edu/hawaii/its/api/service/GroupingOwnerServiceTest.java
@@ -6,9 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
@@ -168,8 +171,38 @@ public class GroupingOwnerServiceTest {
                 () -> groupingOwnerService.getGroupingMembers(
                         TEST_UIDS.get(0), groupingPath, pageNumber, pageSize, sortString, isAscending, searchString));
     }
-
-    @Test
+	
+	// A composite group path must have its ownership check run against the parent grouping path.
+	@Test
+	public void getGroupingMembersNormalizesCompositePathTest() {
+		Integer pageNumber = 1;
+		Integer pageSize = 10;
+		String sortString = "name";
+		Boolean isAscending = true;
+		String searchString = "test";
+		
+		SubjectsResults subjectsResults = groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+		
+		for (GroupType groupType : List.of(GroupType.OWNERS, GroupType.INCLUDE, GroupType.EXCLUDE, GroupType.BASIS)) {
+			clearInvocations(memberService);
+			String compositePath = groupingPath + groupType.value();
+			
+			doReturn(subjectsResults).when(grouperService).getSubjects(compositePath, searchString);
+			doReturn(false).when(memberService).isAdmin(TEST_UIDS.get(0));
+			// Only the parent grouping path grants ownership, not the composite path.
+			doReturn(true).when(memberService).isOwner(groupingPath, TEST_UIDS.get(0));
+			doReturn(false).when(memberService).isOwner(compositePath, TEST_UIDS.get(0));
+			
+			GroupingGroupMembers groupingGroupMembers = groupingOwnerService.getGroupingMembers(
+					TEST_UIDS.get(0), compositePath, pageNumber, pageSize, sortString, isAscending, searchString);
+			
+			assertNotNull(groupingGroupMembers);
+			verify(memberService).isOwner(groupingPath, TEST_UIDS.get(0));
+			verify(memberService, never()).isOwner(compositePath, TEST_UIDS.get(0));
+		}
+	}
+	
+	@Test
     public void getGroupingMembersWhereListedTest() {
         HasMembersResults basis = groupingsTestConfiguration.hasMemberResultsIsMembersBasisTestData();
         HasMembersResults include = groupingsTestConfiguration.hasMemberResultsIsMembersUidTestData();


### PR DESCRIPTION
# Ticket Link

[2219](https://uhawaii.atlassian.net/browse/GROUPINGS-2219?atlOrigin=eyJpIjoiN2JlOGQzYjk3MWNlNDA2OGJmYmU5NGIwNDIwY2ZhZmYiLCJwIjoiaiJ9)

# List of squashed commits

- Fix duplicated grouping list path (#728 )
- use isAdmin instead of isCurrentUserAdmin 

# Test Checklist

- [ ] Exhibits Clear Code Structure:
- [x] Project Unit Tests Passed:
- [ ] Project Integration Tests Passed:
- [ ] Executes Expected Functionality:
- [ ] Tested For Incorrect/Unexpected Inputs:
