### PR TITLE
Optimize member grouping for performance and maintainability

### DIFF
--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -48,10 +48,13 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     private GroupingGroupMembers(GroupingGroupMembers other) {
-        this.resultCode = other.resultCode;
-        this.groupPath = other.groupPath;
-        this.size = other.size;
-        this.members = other.members;
+        this(other, new ArrayList<>(other.members));
+    }
+
+    private GroupingGroupMembers(GroupingGroupMembers other, List<GroupingGroupMember> members) {
+        setResultCode(other.getResultCode());
+        setGroupPath(other.getGroupPath());
+        setGroupingMembers(members);
     }
 
     @Override public String getResultCode() {

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -99,8 +99,11 @@ public class GroupingGroupMembers implements GroupingResult {
         setSize(members.size());
     }
 
-    public GroupingGroupMembers sort(String sortString, boolean isAscending) {
-        Comparator<GroupingGroupMember> comparator = SORT_COMPARATORS.get(sortString);
+    public GroupingGroupMembers sort(SortBy sortBy, boolean isAscending) {
+        if (sortBy == null) {
+            throw new IllegalArgumentException("sortBy must not be null");
+        }
+        Comparator<GroupingGroupMember> comparator = SORT_COMPARATORS.get(sortBy);
 
         // do not sort in-place to prevent any side effects in pagination
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.Subject;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
@@ -14,6 +15,12 @@ import edu.hawaii.its.api.wrapper.SubjectsResults;
  * group such as include, exclude, owners.
  */
 public class GroupingGroupMembers implements GroupingResult {
+    private static final Map<SortBy, Comparator<GroupingGroupMember>> SORT_COMPARATORS = Map.of(
+            SortBy.NAME, Comparator.comparing(GroupingGroupMember::getName),
+            SortBy.UID, Comparator.comparing(GroupingGroupMember::getUid),
+            SortBy.UH_UUID, Comparator.comparing(GroupingGroupMember::getUhUuid)
+    );
+
     private String resultCode;
     private String groupPath;
     private int size;
@@ -42,17 +49,20 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     private GroupingGroupMembers(GroupingGroupMembers other) {
-        this.resultCode = other.resultCode;
-        this.groupPath = other.groupPath;
-        this.size = other.size;
-        this.members = other.members;
+        this(other, new ArrayList<>(other.members));
+    }
+
+    private GroupingGroupMembers(GroupingGroupMembers other, List<GroupingGroupMember> members) {
+        setResultCode(other.getResultCode());
+        setGroupPath(other.getGroupPath());
+        setGroupingMembers(members);
     }
 
     @Override public String getResultCode() {
         return resultCode;
     }
 
-    public void setResultCode(String resultCode) {
+    private void setResultCode(String resultCode) {
         this.resultCode = resultCode;
     }
 
@@ -60,7 +70,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return groupPath;
     }
 
-    public void setGroupPath(String groupPath) {
+    private void setGroupPath(String groupPath) {
         this.groupPath = groupPath;
     }
 
@@ -68,7 +78,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return size;
     }
 
-    public void setSize(int size) {
+    private void setSize(int size) {
         this.size = size;
     }
 
@@ -77,20 +87,25 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     public void setMembers(List<Subject> subjects) {
-        this.members = new ArrayList<>();
+        List<GroupingGroupMember> groupMembers = new ArrayList<>(subjects.size());
         for (Subject subject : subjects) {
-            this.members.add(new GroupingGroupMember(subject));
+            groupMembers.add(new GroupingGroupMember(subject));
         }
+        setGroupingMembers(groupMembers);
     }
 
-    public GroupingGroupMembers sort(String sortString, boolean isAscending) {
-        Map<String, Comparator<GroupingGroupMember>> comparatorMap = Map.of(
-                "name", Comparator.comparing(GroupingGroupMember::getName),
-                "search_string0", Comparator.comparing(GroupingGroupMember::getUid),
-                "subjectId", Comparator.comparing(GroupingGroupMember::getUhUuid)
-        );
-        Comparator<GroupingGroupMember> comparator = comparatorMap.get(sortString);
+    private void setGroupingMembers(List<GroupingGroupMember> members) {
+        this.members = members;
+        setSize(members.size());
+    }
 
+    public GroupingGroupMembers sort(SortBy sortBy, boolean isAscending) {
+        if (sortBy == null) {
+            throw new IllegalArgumentException("sortBy must not be null");
+        }
+        Comparator<GroupingGroupMember> comparator = SORT_COMPARATORS.get(sortBy);
+
+        // do not sort in-place to prevent any side effects in pagination
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
         groupingGroupMembers.members.sort(isAscending ? comparator : comparator.reversed());
 
@@ -98,14 +113,17 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     public GroupingGroupMembers paginate(int pageNumber, int pageSize) {
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber must be greater than 0");
+        }
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
         int fromIndex = (pageNumber - 1) * pageSize;
         int toIndex = Math.min(fromIndex + pageSize, members.size());
 
-        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
-        groupingGroupMembers.members = fromIndex < toIndex
-                ? members.subList(fromIndex, toIndex)
-                : new ArrayList<>();
-
-        return groupingGroupMembers;
+        return fromIndex < toIndex
+                ? new GroupingGroupMembers(this, new ArrayList<>(members.subList(fromIndex, toIndex)))
+                : new GroupingGroupMembers(this, new ArrayList<>());
     }
 }

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -98,6 +98,12 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     public GroupingGroupMembers paginate(int pageNumber, int pageSize) {
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber must be greater than 0");
+        }
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
         int fromIndex = (pageNumber - 1) * pageSize;
         int toIndex = Math.min(fromIndex + pageSize, members.size());
 

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -85,11 +85,17 @@ public class GroupingGroupMembers implements GroupingResult {
         return this.members;
     }
 
-    private void setMembers(List<Subject> subjects) {
-        this.members = new ArrayList<>();
+    public void setMembers(List<Subject> subjects) {
+        List<GroupingGroupMember> groupMembers = new ArrayList<>(subjects.size());
         for (Subject subject : subjects) {
-            this.members.add(new GroupingGroupMember(subject));
+            groupMembers.add(new GroupingGroupMember(subject));
         }
+        setGroupingMembers(groupMembers);
+    }
+
+    private void setGroupingMembers(List<GroupingGroupMember> members) {
+        this.members = members;
+        setSize(members.size());
     }
 
     public GroupingGroupMembers sort(String sortString, boolean isAscending) {

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -5,6 +5,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.wrapper.GetMembersResult;
 import edu.hawaii.its.api.wrapper.Subject;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
@@ -14,10 +15,10 @@ import edu.hawaii.its.api.wrapper.SubjectsResults;
  * group such as include, exclude, owners.
  */
 public class GroupingGroupMembers implements GroupingResult {
-    private static final Map<String, Comparator<GroupingGroupMember>> SORT_COMPARATORS = Map.of(
-            "name", Comparator.comparing(GroupingGroupMember::getName),
-            "search_string0", Comparator.comparing(GroupingGroupMember::getUid),
-            "subjectId", Comparator.comparing(GroupingGroupMember::getUhUuid)
+    private static final Map<SortBy, Comparator<GroupingGroupMember>> SORT_COMPARATORS = Map.of(
+            SortBy.NAME, Comparator.comparing(GroupingGroupMember::getName),
+            SortBy.UID, Comparator.comparing(GroupingGroupMember::getUid),
+            SortBy.UH_UUID, Comparator.comparing(GroupingGroupMember::getUhUuid)
     );
 
     private String resultCode;

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -104,7 +104,9 @@ public class GroupingGroupMembers implements GroupingResult {
             throw new IllegalArgumentException("sortBy must not be null");
         }
         Comparator<GroupingGroupMember> comparator = SORT_COMPARATORS.get(sortBy);
-
+        if (comparator == null) {
+            throw new IllegalArgumentException("Unsupported sortBy: " + sortBy);
+        }
         // do not sort in-place to prevent any side effects in pagination
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
         groupingGroupMembers.members.sort(isAscending ? comparator : comparator.reversed());

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -14,6 +14,12 @@ import edu.hawaii.its.api.wrapper.SubjectsResults;
  * group such as include, exclude, owners.
  */
 public class GroupingGroupMembers implements GroupingResult {
+    private static final Map<String, Comparator<GroupingGroupMember>> SORT_COMPARATORS = Map.of(
+            "name", Comparator.comparing(GroupingGroupMember::getName),
+            "search_string0", Comparator.comparing(GroupingGroupMember::getUid),
+            "subjectId", Comparator.comparing(GroupingGroupMember::getUhUuid)
+    );
+
     private String resultCode;
     private String groupPath;
     private int size;
@@ -84,12 +90,7 @@ public class GroupingGroupMembers implements GroupingResult {
     }
 
     public GroupingGroupMembers sort(String sortString, boolean isAscending) {
-        Map<String, Comparator<GroupingGroupMember>> comparatorMap = Map.of(
-                "name", Comparator.comparing(GroupingGroupMember::getName),
-                "search_string0", Comparator.comparing(GroupingGroupMember::getUid),
-                "subjectId", Comparator.comparing(GroupingGroupMember::getUhUuid)
-        );
-        Comparator<GroupingGroupMember> comparator = comparatorMap.get(sortString);
+        Comparator<GroupingGroupMember> comparator = SORT_COMPARATORS.get(sortString);
 
         // do not sort in-place to prevent any side effects in pagination
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
@@ -108,11 +109,8 @@ public class GroupingGroupMembers implements GroupingResult {
         int fromIndex = (pageNumber - 1) * pageSize;
         int toIndex = Math.min(fromIndex + pageSize, members.size());
 
-        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
-        groupingGroupMembers.members = fromIndex < toIndex
-                ? members.subList(fromIndex, toIndex)
-                : new ArrayList<>();
-
-        return groupingGroupMembers;
+        return fromIndex < toIndex
+                ? new GroupingGroupMembers(this, new ArrayList<>(members.subList(fromIndex, toIndex)))
+                : new GroupingGroupMembers(this, new ArrayList<>());
     }
 }

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -52,7 +52,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return resultCode;
     }
 
-    public void setResultCode(String resultCode) {
+    private void setResultCode(String resultCode) {
         this.resultCode = resultCode;
     }
 
@@ -60,7 +60,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return groupPath;
     }
 
-    public void setGroupPath(String groupPath) {
+    private void setGroupPath(String groupPath) {
         this.groupPath = groupPath;
     }
 
@@ -68,7 +68,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return size;
     }
 
-    public void setSize(int size) {
+    private void setSize(int size) {
         this.size = size;
     }
 
@@ -76,7 +76,7 @@ public class GroupingGroupMembers implements GroupingResult {
         return this.members;
     }
 
-    public void setMembers(List<Subject> subjects) {
+    private void setMembers(List<Subject> subjects) {
         this.members = new ArrayList<>();
         for (Subject subject : subjects) {
             this.members.add(new GroupingGroupMember(subject));

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupMembers.java
@@ -91,6 +91,7 @@ public class GroupingGroupMembers implements GroupingResult {
         );
         Comparator<GroupingGroupMember> comparator = comparatorMap.get(sortString);
 
+        // do not sort in-place to prevent any side effects in pagination
         GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(this);
         groupingGroupMembers.members.sort(isAscending ? comparator : comparator.reversed());
 

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
@@ -93,10 +93,6 @@ public class GroupingGroupsMembers implements GroupingResult {
                 .map(GroupingGroupMember::getUhUuid).collect(Collectors.toSet());
         Set<String> addedUuids = new HashSet<>();
 
-        // Basis plus Include.
-        for (GroupingGroupMember groupingGroupMember : intersectionBasisInclude) {
-            this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Basis & Include"));
-        }
         for (GroupingGroupMember groupingGroupMember : basis) {
             String uhUuid = groupingGroupMember.getUhUuid();
             if (excludeUuids.contains(uhUuid) || !addedUuids.add(uhUuid)) {

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
@@ -1,6 +1,7 @@
 package edu.hawaii.its.api.groupings;
 
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -16,7 +17,7 @@ import edu.hawaii.its.api.wrapper.GetMembersResults;
 public class GroupingGroupsMembers implements GroupingResult {
     private String resultCode;
     private String groupPath;
-    private List<GroupingGroupMembers> groupsMembersList;
+    private Map<String, GroupingGroupMembers> groupsMembersByExtension;
     private boolean isBasis;
     private boolean isInclude;
     private boolean isExclude;
@@ -28,7 +29,7 @@ public class GroupingGroupsMembers implements GroupingResult {
     public GroupingGroupsMembers(GetMembersResults getMembersResults) {
         setGroupPath("");
         setResultCode(getMembersResults.getResultCode());
-        setGroupsMembersList(getMembersResults);
+        indexGroupsMembersByExtension(getMembersResults);
         setAllMembers();
         setBasis(hasMembers(GroupType.BASIS.value()));
         setInclude(hasMembers(GroupType.INCLUDE.value()));
@@ -41,7 +42,7 @@ public class GroupingGroupsMembers implements GroupingResult {
     public GroupingGroupsMembers() {
         setGroupPath("");
         setResultCode("");
-        this.groupsMembersList = new ArrayList<>();
+        this.groupsMembersByExtension = new HashMap<>();
         setAllMembers();
         setBasis(false);
         setInclude(false);
@@ -67,10 +68,16 @@ public class GroupingGroupsMembers implements GroupingResult {
         this.groupPath = groupPath;
     }
 
-    private void setGroupsMembersList(GetMembersResults getMembersResults) {
-        this.groupsMembersList = new ArrayList<>();
+    private void indexGroupsMembersByExtension(GetMembersResults getMembersResults) {
+        this.groupsMembersByExtension = new HashMap<>();
         for (GetMembersResult getMembersResult : getMembersResults.getMembersResults()) {
-            groupsMembersList.add(new GroupingGroupMembers(getMembersResult));
+            GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(getMembersResult);
+            for (GroupType groupType : GroupType.values()) {
+                if (groupingGroupMembers.getGroupPath().endsWith(groupType.value())) {
+                    groupsMembersByExtension.putIfAbsent(groupType.value(), groupingGroupMembers);
+                    break;
+                }
+            }
         }
     }
 
@@ -181,21 +188,11 @@ public class GroupingGroupsMembers implements GroupingResult {
     }
 
     private boolean hasMembers(String groupExtension) {
-        for (GroupingGroupMembers groupingGroupMembers : this.groupsMembersList) {
-            if (groupingGroupMembers.getGroupPath().endsWith(groupExtension)) {
-                return !groupingGroupMembers.getMembers().isEmpty();
-            }
-        }
-        return false;
+        return !getMembersOf(groupExtension).getMembers().isEmpty();
     }
 
     private GroupingGroupMembers getMembersOf(String groupExtension) {
-        for (GroupingGroupMembers groupingGroupMembers : this.groupsMembersList) {
-            if (groupingGroupMembers.getGroupPath().endsWith(groupExtension)) {
-                return groupingGroupMembers;
-            }
-        }
-        return new GroupingGroupMembers();
+        return groupsMembersByExtension.getOrDefault(groupExtension, new GroupingGroupMembers());
     }
 
     public void setPaginationCompleteTrue() {

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
@@ -1,7 +1,10 @@
 package edu.hawaii.its.api.groupings;
 
-import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import edu.hawaii.its.api.type.GroupType;
@@ -14,7 +17,7 @@ import edu.hawaii.its.api.wrapper.GetMembersResults;
 public class GroupingGroupsMembers implements GroupingResult {
     private String resultCode;
     private String groupPath;
-    private List<GroupingGroupMembers> groupsMembersList;
+    private Map<String, GroupingGroupMembers> groupsMembersByExtension;
     private boolean isBasis;
     private boolean isInclude;
     private boolean isExclude;
@@ -26,7 +29,7 @@ public class GroupingGroupsMembers implements GroupingResult {
     public GroupingGroupsMembers(GetMembersResults getMembersResults) {
         setGroupPath("");
         setResultCode(getMembersResults.getResultCode());
-        setGroupsMembersList(getMembersResults);
+        indexGroupsMembersByExtension(getMembersResults);
         setAllMembers();
         setBasis(hasMembers(GroupType.BASIS.value()));
         setInclude(hasMembers(GroupType.INCLUDE.value()));
@@ -39,7 +42,7 @@ public class GroupingGroupsMembers implements GroupingResult {
     public GroupingGroupsMembers() {
         setGroupPath("");
         setResultCode("");
-        this.groupsMembersList = new ArrayList<>();
+        this.groupsMembersByExtension = new HashMap<>();
         setAllMembers();
         setBasis(false);
         setInclude(false);
@@ -65,10 +68,16 @@ public class GroupingGroupsMembers implements GroupingResult {
         this.groupPath = groupPath;
     }
 
-    private void setGroupsMembersList(GetMembersResults getMembersResults) {
-        this.groupsMembersList = new ArrayList<>();
+    private void indexGroupsMembersByExtension(GetMembersResults getMembersResults) {
+        this.groupsMembersByExtension = new HashMap<>();
         for (GetMembersResult getMembersResult : getMembersResults.getMembersResults()) {
-            groupsMembersList.add(new GroupingGroupMembers(getMembersResult));
+            GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(getMembersResult);
+            for (GroupType groupType : GroupType.values()) {
+                if (groupingGroupMembers.getGroupPath().endsWith(groupType.value())) {
+                    groupsMembersByExtension.putIfAbsent(groupType.value(), groupingGroupMembers);
+                    break;
+                }
+            }
         }
     }
 
@@ -78,27 +87,32 @@ public class GroupingGroupsMembers implements GroupingResult {
         List<GroupingGroupMember> include = getGroupingInclude().getMembers();
         List<GroupingGroupMember> exclude = getGroupingExclude().getMembers();
 
-        List<GroupingGroupMember> intersectionBasisInclude = basis.stream()
-                .distinct().filter(groupingsGroupMember -> include.stream()
-                        .anyMatch(includeMember -> includeMember.getUhUuid().equals(groupingsGroupMember.getUhUuid())))
-                .collect(Collectors.toList());
+        Set<String> includeUuids = include.stream()
+                .map(GroupingGroupMember::getUhUuid).collect(Collectors.toSet());
+        Set<String> excludeUuids = exclude.stream()
+                .map(GroupingGroupMember::getUhUuid).collect(Collectors.toSet());
+        Set<String> addedUuids = new HashSet<>();
 
         // Basis plus Include.
         for (GroupingGroupMember groupingGroupMember : intersectionBasisInclude) {
             this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Basis & Include"));
         }
         for (GroupingGroupMember groupingGroupMember : basis) {
-            if (this.allMembers.getMembers().stream()
-                    .noneMatch(groupingMember -> groupingMember.getUhUuid().equals(groupingGroupMember.getUhUuid()))) {
-                this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Basis"));
+            String uhUuid = groupingGroupMember.getUhUuid();
+            if (excludeUuids.contains(uhUuid) || !addedUuids.add(uhUuid)) {
+                continue;
             }
+            String whereListed = includeUuids.contains(uhUuid) ? "Basis & Include" : "Basis";
+            this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, whereListed));
         }
         for (GroupingGroupMember groupingGroupMember : include) {
-            if (this.allMembers.getMembers().stream()
-                    .noneMatch(groupingMember -> groupingMember.getUhUuid().equals(groupingGroupMember.getUhUuid()))) {
-                this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Include"));
+            String uhUuid = groupingGroupMember.getUhUuid();
+            if (excludeUuids.contains(uhUuid) || !addedUuids.add(uhUuid)) {
+                continue;
             }
+            this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Include"));
         }
+    }
 
         // Minus Exclude
         this.allMembers.getMembers().removeIf(groupingMember -> exclude.stream()
@@ -174,21 +188,11 @@ public class GroupingGroupsMembers implements GroupingResult {
     }
 
     private boolean hasMembers(String groupExtension) {
-        for (GroupingGroupMembers groupingGroupMembers : this.groupsMembersList) {
-            if (groupingGroupMembers.getGroupPath().endsWith(groupExtension)) {
-                return !groupingGroupMembers.getMembers().isEmpty();
-            }
-        }
-        return false;
+        return !getMembersOf(groupExtension).getMembers().isEmpty();
     }
 
     private GroupingGroupMembers getMembersOf(String groupExtension) {
-        for (GroupingGroupMembers groupingGroupMembers : this.groupsMembersList) {
-            if (groupingGroupMembers.getGroupPath().endsWith(groupExtension)) {
-                return groupingGroupMembers;
-            }
-        }
-        return new GroupingGroupMembers();
+        return groupsMembersByExtension.getOrDefault(groupExtension, new GroupingGroupMembers());
     }
 
     public void setPaginationCompleteTrue() {

--- a/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
+++ b/src/main/java/edu/hawaii/its/api/groupings/GroupingGroupsMembers.java
@@ -2,6 +2,8 @@ package edu.hawaii.its.api.groupings;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import edu.hawaii.its.api.type.GroupType;
@@ -78,27 +80,32 @@ public class GroupingGroupsMembers implements GroupingResult {
         List<GroupingGroupMember> include = getGroupingInclude().getMembers();
         List<GroupingGroupMember> exclude = getGroupingExclude().getMembers();
 
-        List<GroupingGroupMember> intersectionBasisInclude = basis.stream()
-                .distinct().filter(groupingsGroupMember -> include.stream()
-                        .anyMatch(includeMember -> includeMember.getUhUuid().equals(groupingsGroupMember.getUhUuid())))
-                .collect(Collectors.toList());
+        Set<String> includeUuids = include.stream()
+                .map(GroupingGroupMember::getUhUuid).collect(Collectors.toSet());
+        Set<String> excludeUuids = exclude.stream()
+                .map(GroupingGroupMember::getUhUuid).collect(Collectors.toSet());
+        Set<String> addedUuids = new HashSet<>();
 
         // Basis plus Include.
         for (GroupingGroupMember groupingGroupMember : intersectionBasisInclude) {
             this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Basis & Include"));
         }
         for (GroupingGroupMember groupingGroupMember : basis) {
-            if (this.allMembers.getMembers().stream()
-                    .noneMatch(groupingMember -> groupingMember.getUhUuid().equals(groupingGroupMember.getUhUuid()))) {
-                this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Basis"));
+            String uhUuid = groupingGroupMember.getUhUuid();
+            if (excludeUuids.contains(uhUuid) || !addedUuids.add(uhUuid)) {
+                continue;
             }
+            String whereListed = includeUuids.contains(uhUuid) ? "Basis & Include" : "Basis";
+            this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, whereListed));
         }
         for (GroupingGroupMember groupingGroupMember : include) {
-            if (this.allMembers.getMembers().stream()
-                    .noneMatch(groupingMember -> groupingMember.getUhUuid().equals(groupingGroupMember.getUhUuid()))) {
-                this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Include"));
+            String uhUuid = groupingGroupMember.getUhUuid();
+            if (excludeUuids.contains(uhUuid) || !addedUuids.add(uhUuid)) {
+                continue;
             }
+            this.allMembers.getMembers().add(new GroupingMember(groupingGroupMember, "Include"));
         }
+    }
 
         // Minus Exclude
         this.allMembers.getMembers().removeIf(groupingMember -> exclude.stream()

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -23,6 +23,7 @@ import edu.hawaii.its.api.groupings.GroupingOptAttributes;
 import edu.hawaii.its.api.groupings.GroupingSyncDestination;
 import edu.hawaii.its.api.groupings.GroupingSyncDestinations;
 import edu.hawaii.its.api.type.GroupType;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.Strings;
 import edu.hawaii.its.api.wrapper.AttributesResult;
@@ -80,6 +81,7 @@ public class GroupingOwnerService {
         log.debug(String.format(
                 "paginatedGrouping; currentUser: %s; groupPaths: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b;",
                 currentUser, groupPaths, pageNumber, pageSize, sortString, isAscending));
+        validatePagination(pageNumber, pageSize);
         GetMembersResults getMembersResults = grouperService.getMembersResults(
                 currentUser,
                 groupPaths,
@@ -98,6 +100,7 @@ public class GroupingOwnerService {
         log.debug(String.format(
                 "getGroupingMembers; currentUser: %s; groupingPath: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b;",
                 currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending));
+        validatePagination(pageNumber, pageSize);
         GetMembersResult getMembersResult = grouperService.getMembersResult(
                 currentUser,
                 groupingPath,
@@ -121,13 +124,31 @@ public class GroupingOwnerService {
             throw new AccessDeniedException();
         }
 
+        validatePagination(pageNumber, pageSize);
+
         if (Strings.isEmpty(searchString)) {
             return getGroupingMembers(currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending);
         }
 
         SubjectsResults subjectsResults = grouperService.getSubjects(groupingPath, searchString);
+        SortBy sortBy = SortBy.find(sortString);
 
-        return new GroupingGroupMembers(subjectsResults).sort(sortString, isAscending).paginate(pageNumber, pageSize);
+        return new GroupingGroupMembers(subjectsResults).sort(sortBy, isAscending).paginate(pageNumber, pageSize);
+    }
+
+    private void validatePagination(Integer pageNumber, Integer pageSize) {
+        if (pageNumber == null) {
+            throw new IllegalArgumentException("pageNumber must be provided");
+        }
+        if (pageSize == null) {
+            throw new IllegalArgumentException("pageSize must be provided");
+        }
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber must be greater than 0");
+        }
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
     }
 
     public GroupingMembers getGroupingMembersWhereListed(String currentUser, String groupingPath,

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -23,6 +23,7 @@ import edu.hawaii.its.api.groupings.GroupingOptAttributes;
 import edu.hawaii.its.api.groupings.GroupingSyncDestination;
 import edu.hawaii.its.api.groupings.GroupingSyncDestinations;
 import edu.hawaii.its.api.type.GroupType;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.util.JsonUtil;
 import edu.hawaii.its.api.util.Strings;
 import edu.hawaii.its.api.wrapper.AttributesResult;
@@ -130,8 +131,9 @@ public class GroupingOwnerService {
         }
 
         SubjectsResults subjectsResults = grouperService.getSubjects(groupingPath, searchString);
+        SortBy sortBy = SortBy.find(sortString);
 
-        return new GroupingGroupMembers(subjectsResults).sort(sortString, isAscending).paginate(pageNumber, pageSize);
+        return new GroupingGroupMembers(subjectsResults).sort(sortBy, isAscending).paginate(pageNumber, pageSize);
     }
 
     private void validatePagination(Integer pageNumber, Integer pageSize) {

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -98,6 +98,7 @@ public class GroupingOwnerService {
         log.debug(String.format(
                 "getGroupingMembers; currentUser: %s; groupingPath: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b;",
                 currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending));
+        validatePagination(pageNumber, pageSize);
         GetMembersResult getMembersResult = grouperService.getMembersResult(
                 currentUser,
                 groupingPath,
@@ -121,6 +122,8 @@ public class GroupingOwnerService {
             throw new AccessDeniedException();
         }
 
+        validatePagination(pageNumber, pageSize);
+
         if (Strings.isEmpty(searchString)) {
             return getGroupingMembers(currentUser, groupingPath, pageNumber, pageSize, sortString, isAscending);
         }
@@ -128,6 +131,21 @@ public class GroupingOwnerService {
         SubjectsResults subjectsResults = grouperService.getSubjects(groupingPath, searchString);
 
         return new GroupingGroupMembers(subjectsResults).sort(sortString, isAscending).paginate(pageNumber, pageSize);
+    }
+
+    private void validatePagination(Integer pageNumber, Integer pageSize) {
+        if (pageNumber == null) {
+            throw new IllegalArgumentException("pageNumber must be provided");
+        }
+        if (pageSize == null) {
+            throw new IllegalArgumentException("pageSize must be provided");
+        }
+        if (pageNumber < 1) {
+            throw new IllegalArgumentException("pageNumber must be greater than 0");
+        }
+        if (pageSize < 1) {
+            throw new IllegalArgumentException("pageSize must be greater than 0");
+        }
     }
 
     public GroupingMembers getGroupingMembersWhereListed(String currentUser, String groupingPath,

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -131,7 +131,18 @@ public class GroupingOwnerService {
         }
 
         SubjectsResults subjectsResults = grouperService.getSubjects(groupingPath, searchString);
-        SortBy sortBy = SortBy.find(sortString);
+
+        SortBy sortBy = null;
+        for (SortBy candidate : SortBy.values()) {
+            if (candidate.sortString().equalsIgnoreCase(sortString)
+                    || candidate.value().equalsIgnoreCase(sortString)) {
+                sortBy = candidate;
+                break;
+            }
+        }
+        if (sortBy == null) {
+            throw new IllegalArgumentException("Invalid sortBy: " + sortString);
+        }
 
         return new GroupingGroupMembers(subjectsResults).sort(sortBy, isAscending).paginate(pageNumber, pageSize);
     }

--- a/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
+++ b/src/main/java/edu/hawaii/its/api/service/GroupingOwnerService.java
@@ -80,6 +80,7 @@ public class GroupingOwnerService {
         log.debug(String.format(
                 "paginatedGrouping; currentUser: %s; groupPaths: %s; pageNumber: %d; pageSize: %d; sortString: %s; isAscending: %b;",
                 currentUser, groupPaths, pageNumber, pageSize, sortString, isAscending));
+        validatePagination(pageNumber, pageSize);
         GetMembersResults getMembersResults = grouperService.getMembersResults(
                 currentUser,
                 groupPaths,

--- a/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
@@ -18,6 +18,7 @@ import edu.internet2.middleware.grouperClientExt.com.fasterxml.jackson.annotatio
  */
 public class SubjectsResults extends Results {
     private WsGetSubjectsResults wsGetSubjectsResults;
+    private List<Subject> subjects;
 
     public SubjectsResults(WsGetSubjectsResults wsGetSubjectsResults) {
         if (wsGetSubjectsResults == null) {
@@ -40,6 +41,13 @@ public class SubjectsResults extends Results {
     }
 
     public List<Subject> getSubjects() {
+        if (subjects == null) {
+            subjects = buildSubjects();
+        }
+        return new ArrayList<>(subjects);
+    }
+
+    private List<Subject> buildSubjects() {
         List<Subject> subjects = new ArrayList<>();
         WsSubject[] wsSubjects = wsGetSubjectsResults.getWsSubjects();
         if (isEmpty(wsSubjects)) {
@@ -55,7 +63,7 @@ public class SubjectsResults extends Results {
             if (subject.getResultCode().equals("SUCCESS") && !subject.hasUHAttributes()) {
                 continue;
             }
-            subjects.add(new Subject(wsSubject));
+            subjects.add(subject);
         }
         return subjects;
     }

--- a/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
@@ -18,6 +18,7 @@ import edu.internet2.middleware.grouperClientExt.com.fasterxml.jackson.annotatio
  */
 public class SubjectsResults extends Results {
     private WsGetSubjectsResults wsGetSubjectsResults;
+    private List<Subject> subjects;
 
     public SubjectsResults(WsGetSubjectsResults wsGetSubjectsResults) {
         if (wsGetSubjectsResults == null) {
@@ -40,6 +41,13 @@ public class SubjectsResults extends Results {
     }
 
     public List<Subject> getSubjects() {
+        if (subjects == null) {
+            subjects = buildSubjects();
+        }
+        return new ArrayList<>(subjects);
+    }
+
+    private List<Subject> buildSubjects() {
         List<Subject> subjects = new ArrayList<>();
         WsSubject[] wsSubjects = wsGetSubjectsResults.getWsSubjects();
         if (isEmpty(wsSubjects)) {

--- a/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
+++ b/src/main/java/edu/hawaii/its/api/wrapper/SubjectsResults.java
@@ -55,7 +55,7 @@ public class SubjectsResults extends Results {
             if (subject.getResultCode().equals("SUCCESS") && !subject.hasUHAttributes()) {
                 continue;
             }
-            subjects.add(new Subject(wsSubject));
+            subjects.add(subject);
         }
         return subjects;
     }

--- a/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import edu.hawaii.its.api.configuration.GroupingsTestConfiguration;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.wrapper.GetMembersResults;
 import edu.hawaii.its.api.wrapper.Subject;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
@@ -72,15 +73,15 @@ public class GroupingGroupMembersTest {
         GroupingGroupMember firstMember = members.get(0);
         GroupingGroupMember secondMember = members.get(1);
 
-        groupingGroupMembers = groupingGroupMembers.sort("name", false);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.NAME, false);
         assertEquals(firstMember.getName(), groupingGroupMembers.getMembers().get(1).getName());
         assertEquals(secondMember.getName(), groupingGroupMembers.getMembers().get(0).getName());
 
-        groupingGroupMembers = groupingGroupMembers.sort("search_string0", true);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.UID, true);
         assertEquals(firstMember.getUid(), groupingGroupMembers.getMembers().get(0).getUid());
         assertEquals(secondMember.getUid(), groupingGroupMembers.getMembers().get(1).getUid());
 
-        groupingGroupMembers = groupingGroupMembers.sort("subjectId", false);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.UH_UUID, false);
         assertEquals(firstMember.getUhUuid(), groupingGroupMembers.getMembers().get(1).getUhUuid());
         assertEquals(secondMember.getUhUuid(), groupingGroupMembers.getMembers().get(0).getUhUuid());
     }
@@ -97,12 +98,37 @@ public class GroupingGroupMembersTest {
             subjects.addAll(duplicateSubjects);
         }
         groupingGroupMembers.setMembers(subjects);
+        assertEquals(subjects.size(), groupingGroupMembers.getSize());
 
         assertEquals(20, groupingGroupMembers.paginate(1, 20).getMembers().size());
         assertEquals(12, groupingGroupMembers.paginate(2, 20).getMembers().size());
         assertEquals(0, groupingGroupMembers.paginate(3, 20).getMembers().size());
         assertEquals(0, groupingGroupMembers.paginate(10, 20).getMembers().size());
-        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(-1, 20));
-        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(0, 20));
+    }
+
+    @Test
+    public void testPaginateValidatesPageArguments() {
+        SubjectsResults subjectsResults =
+                groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(subjectsResults);
+
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(0, 20));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(-1, 20));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(1, 0));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(1, -1));
+    }
+
+    @Test
+    public void testPaginateDoesNotShareListStateWithOriginal() {
+        SubjectsResults subjectsResults =
+                groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(subjectsResults);
+
+        GroupingGroupMembers paginated = groupingGroupMembers.paginate(1, 1);
+        List<GroupingGroupMember> expectedPage = new ArrayList<>(paginated.getMembers());
+
+        groupingGroupMembers.getMembers().clear();
+
+        assertEquals(expectedPage, paginated.getMembers());
     }
 }

--- a/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
@@ -14,6 +14,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import edu.hawaii.its.api.configuration.GroupingsTestConfiguration;
 import edu.hawaii.its.api.configuration.SpringBootWebApplication;
+import edu.hawaii.its.api.type.SortBy;
 import edu.hawaii.its.api.wrapper.GetMembersResults;
 import edu.hawaii.its.api.wrapper.Subject;
 import edu.hawaii.its.api.wrapper.SubjectsResults;
@@ -103,7 +104,31 @@ public class GroupingGroupMembersTest {
         assertEquals(12, groupingGroupMembers.paginate(2, 20).getMembers().size());
         assertEquals(0, groupingGroupMembers.paginate(3, 20).getMembers().size());
         assertEquals(0, groupingGroupMembers.paginate(10, 20).getMembers().size());
-        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(-1, 20));
-        assertThrows(IndexOutOfBoundsException.class, () -> groupingGroupMembers.paginate(0, 20));
+    }
+
+    @Test
+    public void testPaginateValidatesPageArguments() {
+        SubjectsResults subjectsResults =
+                groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(subjectsResults);
+
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(0, 20));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(-1, 20));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(1, 0));
+        assertThrows(IllegalArgumentException.class, () -> groupingGroupMembers.paginate(1, -1));
+    }
+
+    @Test
+    public void testPaginateDoesNotShareListStateWithOriginal() {
+        SubjectsResults subjectsResults =
+                groupingsTestConfiguration.getSubjectsResultsSuccessTestData();
+        GroupingGroupMembers groupingGroupMembers = new GroupingGroupMembers(subjectsResults);
+
+        GroupingGroupMembers paginated = groupingGroupMembers.paginate(1, 1);
+        List<GroupingGroupMember> expectedPage = new ArrayList<>(paginated.getMembers());
+
+        groupingGroupMembers.getMembers().clear();
+
+        assertEquals(expectedPage, paginated.getMembers());
     }
 }

--- a/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
+++ b/src/test/java/edu/hawaii/its/api/groupings/GroupingGroupMembersTest.java
@@ -72,15 +72,15 @@ public class GroupingGroupMembersTest {
         GroupingGroupMember firstMember = members.get(0);
         GroupingGroupMember secondMember = members.get(1);
 
-        groupingGroupMembers = groupingGroupMembers.sort("name", false);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.NAME, false);
         assertEquals(firstMember.getName(), groupingGroupMembers.getMembers().get(1).getName());
         assertEquals(secondMember.getName(), groupingGroupMembers.getMembers().get(0).getName());
 
-        groupingGroupMembers = groupingGroupMembers.sort("search_string0", true);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.UID, true);
         assertEquals(firstMember.getUid(), groupingGroupMembers.getMembers().get(0).getUid());
         assertEquals(secondMember.getUid(), groupingGroupMembers.getMembers().get(1).getUid());
 
-        groupingGroupMembers = groupingGroupMembers.sort("subjectId", false);
+        groupingGroupMembers = groupingGroupMembers.sort(SortBy.UH_UUID, false);
         assertEquals(firstMember.getUhUuid(), groupingGroupMembers.getMembers().get(1).getUhUuid());
         assertEquals(secondMember.getUhUuid(), groupingGroupMembers.getMembers().get(0).getUhUuid());
     }
@@ -97,6 +97,7 @@ public class GroupingGroupMembersTest {
             subjects.addAll(duplicateSubjects);
         }
         groupingGroupMembers.setMembers(subjects);
+        assertEquals(subjects.size(), groupingGroupMembers.getSize());
 
         assertEquals(20, groupingGroupMembers.paginate(1, 20).getMembers().size());
         assertEquals(12, groupingGroupMembers.paginate(2, 20).getMembers().size());


### PR DESCRIPTION
# Ticket Link

[Ticket](https://uhawaii.atlassian.net/browse/GROUPINGS-2156?atlOrigin=eyJpIjoiYTcyMzkwNzExOWY3NDNlMGExMGU2NGYyMzQyYWQwZWEiLCJwIjoiaiJ9)

# List of squashed commits

- privatize setter methods
- add index validation for pagination
- clean up pagination
- clean up setMembers flow
- use SortBy enum instead of raw string
- add exception for illegal sort argument
- reduce double object creation when getting subjects
- prevent unnecessary array parses when subjects is non-null
- use sets for optimization
- use maps to optimize member grouping
- update tests to use sortby enum
- update pagination tests

# Test Checklist

- [ ] Exhibits Clear Code Structure:
- [ ] Project Unit Tests Passed:
- [ ] Project Integration Tests Passed:
- [ ] Executes Expected Functionality:
- [ ] Tested For Incorrect/Unexpected Inputs:
